### PR TITLE
修复AI校对润色稿应用逻辑

### DIFF
--- a/ModuleFolders/Service/Proofreader/ProofreaderTask.py
+++ b/ModuleFolders/Service/Proofreader/ProofreaderTask.py
@@ -81,7 +81,7 @@ class ProofreaderTask(Base):
         # 上下文 (简化格式)
         if self.previous_items:
             context_list = []
-            for item in self.previous_items[-5:]:  # 最多5条上文
+            for item in self.previous_items:
                 context_list.append({
                     "source": item.get("source", "")[:100],
                     "translation": item.get("translation", "")[:100]

--- a/ModuleFolders/Tests/test_ai_proofread_export.py
+++ b/ModuleFolders/Tests/test_ai_proofread_export.py
@@ -130,24 +130,25 @@ class AIProofreadExportTests(unittest.TestCase):
             CacheItem(
                 text_index=1,
                 translation_status=TranslationStatus.AI_PROOFREAD,
-                translated_text="translation",
-                polished_text="proofread polish",
+                translated_text="proofread translation",
+                polished_text="stale polish",
             ),
             CacheItem(
                 text_index=2,
                 translation_status=TranslationStatus.AI_PROOFREAD,
-                translated_text="proofread translation",
-                polished_text="",
+                translated_text="",
+                polished_text="proofread polish",
             ),
         ]
         project.add_file(cache_file)
 
         ExportFlow._normalize_ai_proofread_status_for_export(project)
 
-        self.assertEqual(cache_file.items[0].translation_status, TranslationStatus.POLISHED)
-        self.assertEqual(cache_file.items[0].final_text, "proofread polish")
-        self.assertEqual(cache_file.items[1].translation_status, TranslationStatus.TRANSLATED)
-        self.assertEqual(cache_file.items[1].final_text, "proofread translation")
+        self.assertEqual(cache_file.items[0].translation_status, TranslationStatus.TRANSLATED)
+        self.assertEqual(cache_file.items[0].polished_text, "")
+        self.assertEqual(cache_file.items[0].final_text, "proofread translation")
+        self.assertEqual(cache_file.items[1].translation_status, TranslationStatus.POLISHED)
+        self.assertEqual(cache_file.items[1].final_text, "proofread polish")
 
     def test_normalized_ai_proofread_cache_is_written_by_txt_writer(self):
         cache_file = CacheFile(storage_path="book.txt", file_project_type="Txt")

--- a/ModuleFolders/Tests/test_ai_proofread_export.py
+++ b/ModuleFolders/Tests/test_ai_proofread_export.py
@@ -1,0 +1,186 @@
+import json as std_json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("rapidjson", std_json)
+
+
+class _MsgspecJson:
+    @staticmethod
+    def encode(value):
+        return std_json.dumps(value).encode("utf-8")
+
+    @staticmethod
+    def decode(value, type=None):
+        return std_json.loads(value)
+
+
+sys.modules.setdefault(
+    "msgspec",
+    SimpleNamespace(json=_MsgspecJson, ValidationError=ValueError),
+)
+
+from ModuleFolders.Infrastructure.Cache.CacheFile import CacheFile
+from ModuleFolders.Infrastructure.Cache.CacheItem import CacheItem, TranslationStatus
+from ModuleFolders.Infrastructure.Cache.CacheProject import CacheProject
+from ModuleFolders.Domain.FileOutputer.BaseWriter import OutputConfig, TranslationOutputConfig
+from ModuleFolders.Domain.FileOutputer.TxtWriter import TxtWriter
+from ModuleFolders.UserInterface.AIProofreadMenu import AIProofreadMenu
+from ModuleFolders.UserInterface.ExportFlow import ExportFlow
+
+
+class AIProofreadExportTests(unittest.TestCase):
+    def _report_item(self, translated_text, target_field=None):
+        ai_check = {}
+        if target_field:
+            ai_check["target_field"] = target_field
+        return SimpleNamespace(translated_text=translated_text, ai_check=ai_check)
+
+    def test_translated_correction_clears_stale_polished_text(self):
+        cache_item = CacheItem(
+            text_index=1,
+            translation_status=TranslationStatus.POLISHED,
+            translated_text="old translation",
+            polished_text="stale polish",
+        )
+        report_item = self._report_item("old translation", "translated_text")
+
+        target_field = AIProofreadMenu._apply_correction_to_cache_item(
+            report_item,
+            cache_item,
+            "fixed translation",
+        )
+
+        self.assertEqual(target_field, "translated_text")
+        self.assertEqual(cache_item.translated_text, "fixed translation")
+        self.assertEqual(cache_item.polished_text, "")
+        self.assertEqual(cache_item.translation_status, TranslationStatus.TRANSLATED)
+        self.assertEqual(cache_item.final_text, "fixed translation")
+
+    def test_polished_correction_keeps_polished_output(self):
+        cache_item = CacheItem(
+            text_index=1,
+            translation_status=TranslationStatus.POLISHED,
+            translated_text="translation",
+            polished_text="old polish",
+        )
+        report_item = self._report_item("old polish", "polished_text")
+
+        target_field = AIProofreadMenu._apply_correction_to_cache_item(
+            report_item,
+            cache_item,
+            "fixed polish",
+        )
+
+        self.assertEqual(target_field, "polished_text")
+        self.assertEqual(cache_item.translated_text, "translation")
+        self.assertEqual(cache_item.polished_text, "fixed polish")
+        self.assertEqual(cache_item.translation_status, TranslationStatus.POLISHED)
+        self.assertEqual(cache_item.final_text, "fixed polish")
+
+    def test_legacy_report_matches_translated_text_before_fallback(self):
+        cache_item = CacheItem(
+            text_index=1,
+            translation_status=TranslationStatus.POLISHED,
+            translated_text="reported translation",
+            polished_text="existing polish",
+        )
+        report_item = self._report_item("reported translation")
+
+        target_field = AIProofreadMenu._apply_correction_to_cache_item(
+            report_item,
+            cache_item,
+            "fixed translation",
+        )
+
+        self.assertEqual(target_field, "translated_text")
+        self.assertEqual(cache_item.translated_text, "fixed translation")
+        self.assertEqual(cache_item.polished_text, "")
+        self.assertEqual(cache_item.translation_status, TranslationStatus.TRANSLATED)
+        self.assertEqual(cache_item.final_text, "fixed translation")
+
+    def test_legacy_report_prefers_translated_text_when_both_fields_match(self):
+        cache_item = CacheItem(
+            text_index=1,
+            translation_status=TranslationStatus.POLISHED,
+            translated_text="same text",
+            polished_text="same text",
+        )
+        report_item = self._report_item("same text")
+
+        target_field = AIProofreadMenu._apply_correction_to_cache_item(
+            report_item,
+            cache_item,
+            "fixed translation",
+        )
+
+        self.assertEqual(target_field, "translated_text")
+        self.assertEqual(cache_item.translated_text, "fixed translation")
+        self.assertEqual(cache_item.polished_text, "")
+        self.assertEqual(cache_item.translation_status, TranslationStatus.TRANSLATED)
+
+    def test_ai_proofread_status_is_normalized_for_export(self):
+        project = CacheProject(project_type="Txt")
+        cache_file = CacheFile(storage_path="book.txt", file_project_type="Txt")
+        cache_file.items = [
+            CacheItem(
+                text_index=1,
+                translation_status=TranslationStatus.AI_PROOFREAD,
+                translated_text="translation",
+                polished_text="proofread polish",
+            ),
+            CacheItem(
+                text_index=2,
+                translation_status=TranslationStatus.AI_PROOFREAD,
+                translated_text="proofread translation",
+                polished_text="",
+            ),
+        ]
+        project.add_file(cache_file)
+
+        ExportFlow._normalize_ai_proofread_status_for_export(project)
+
+        self.assertEqual(cache_file.items[0].translation_status, TranslationStatus.POLISHED)
+        self.assertEqual(cache_file.items[0].final_text, "proofread polish")
+        self.assertEqual(cache_file.items[1].translation_status, TranslationStatus.TRANSLATED)
+        self.assertEqual(cache_file.items[1].final_text, "proofread translation")
+
+    def test_normalized_ai_proofread_cache_is_written_by_txt_writer(self):
+        cache_file = CacheFile(storage_path="book.txt", file_project_type="Txt")
+        cache_file.items = [
+            CacheItem(
+                text_index=1,
+                translation_status=TranslationStatus.AI_PROOFREAD,
+                source_text="source",
+                translated_text="proofread translation",
+                polished_text="",
+                extra={"line_break": 0},
+            )
+        ]
+        project = CacheProject(project_type="Txt")
+        project.add_file(cache_file)
+
+        ExportFlow._normalize_ai_proofread_status_for_export(project)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = Path(tmp_dir) / "book_translated.txt"
+            writer = TxtWriter(
+                OutputConfig(
+                    translated_config=TranslationOutputConfig(True, "", Path(tmp_dir))
+                )
+            )
+            writer.write_translated_file(
+                output_path,
+                cache_file,
+                task_config=SimpleNamespace(keep_original_encoding=True),
+            )
+
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "proofread translation\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ModuleFolders/UserInterface/AIProofreadMenu.py
+++ b/ModuleFolders/UserInterface/AIProofreadMenu.py
@@ -438,13 +438,20 @@ class AIProofreadMenu:
                         if cache_item.text_index == text_index:
                             target_field = item.ai_check.get("target_field")
                             if target_field not in ("translated_text", "polished_text"):
-                                target_field = "polished_text" if cache_item.polished_text.strip() else "translated_text"
+                                report_text = item.translated_text or ""
+                                if report_text == (cache_item.polished_text or ""):
+                                    target_field = "polished_text"
+                                elif report_text == (cache_item.translated_text or ""):
+                                    target_field = "translated_text"
+                                else:
+                                    target_field = "translated_text"
 
                             if target_field == "polished_text":
                                 cache_item.polished_text = corrected_text
                                 cache_item.translation_status = TranslationStatus.POLISHED
                             else:
                                 cache_item.translated_text = corrected_text
+                                cache_item.polished_text = ""
                                 cache_item.translation_status = TranslationStatus.TRANSLATED
 
                             if cache_item.extra is None:

--- a/ModuleFolders/UserInterface/AIProofreadMenu.py
+++ b/ModuleFolders/UserInterface/AIProofreadMenu.py
@@ -42,6 +42,41 @@ class AIProofreadMenu:
     def i18n(self):
         return self.host.i18n
 
+    @staticmethod
+    def _resolve_correction_target_field(report_item, cache_item) -> str:
+        """确定AI校对修正应写回的缓存字段。"""
+        target_field = report_item.ai_check.get("target_field")
+        if target_field in ("translated_text", "polished_text"):
+            return target_field
+
+        report_text = report_item.translated_text or ""
+        if report_text == (cache_item.translated_text or ""):
+            return "translated_text"
+        if report_text == (cache_item.polished_text or ""):
+            return "polished_text"
+        return "translated_text"
+
+    @classmethod
+    def _apply_correction_to_cache_item(cls, report_item, cache_item, corrected_text: str) -> str:
+        """应用AI校对修正，并返回实际写回字段。"""
+        target_field = cls._resolve_correction_target_field(report_item, cache_item)
+
+        if target_field == "polished_text":
+            cache_item.polished_text = corrected_text
+            cache_item.translation_status = TranslationStatus.POLISHED
+        else:
+            cache_item.translated_text = corrected_text
+            cache_item.polished_text = ""
+            cache_item.translation_status = TranslationStatus.TRANSLATED
+
+        if cache_item.extra is None:
+            cache_item.extra = {}
+        cache_item.extra["ai_proofread"] = {
+            "target_field": target_field,
+            "applied": True,
+        }
+        return target_field
+
     def show(self):
         """显示AI校对菜单（入口方法）"""
         from ModuleFolders.UserInterface.Proofreader import ProofreadTUI
@@ -436,30 +471,7 @@ class AIProofreadMenu:
                 for cache_file in project.files.values():
                     for cache_item in cache_file.items:
                         if cache_item.text_index == text_index:
-                            target_field = item.ai_check.get("target_field")
-                            if target_field not in ("translated_text", "polished_text"):
-                                report_text = item.translated_text or ""
-                                if report_text == (cache_item.polished_text or ""):
-                                    target_field = "polished_text"
-                                elif report_text == (cache_item.translated_text or ""):
-                                    target_field = "translated_text"
-                                else:
-                                    target_field = "translated_text"
-
-                            if target_field == "polished_text":
-                                cache_item.polished_text = corrected_text
-                                cache_item.translation_status = TranslationStatus.POLISHED
-                            else:
-                                cache_item.translated_text = corrected_text
-                                cache_item.polished_text = ""
-                                cache_item.translation_status = TranslationStatus.TRANSLATED
-
-                            if cache_item.extra is None:
-                                cache_item.extra = {}
-                            cache_item.extra["ai_proofread"] = {
-                                "target_field": target_field,
-                                "applied": True,
-                            }
+                            self._apply_correction_to_cache_item(item, cache_item, corrected_text)
                             applied_count += 1
                             break
 

--- a/ModuleFolders/UserInterface/AIProofreadMenu.py
+++ b/ModuleFolders/UserInterface/AIProofreadMenu.py
@@ -149,12 +149,20 @@ class AIProofreadMenu:
             if status not in [TranslationStatus.TRANSLATED, TranslationStatus.POLISHED]:
                 continue
             source = item.get("source_text", "")
-            target = item.get("translated_text", "") or item.get("polished_text", "")
+            polished_text = item.get("polished_text", "")
+            translated_text = item.get("translated_text", "")
+            if status == TranslationStatus.POLISHED and polished_text:
+                target = polished_text
+                target_field = "polished_text"
+            else:
+                target = translated_text
+                target_field = "translated_text"
             if source and target:
                 to_check.append({
                     "index": item.get("text_index", 0),
                     "source": source,
-                    "translation": target
+                    "translation": target,
+                    "target_field": target_field,
                 })
 
         console.print(f"[blue]开始校对 {len(to_check)} 条内容...[/blue]")
@@ -209,9 +217,17 @@ class AIProofreadMenu:
         rpm_limit = self.config.get("rpm_limit", 60)
         request_limiter.set_limit(tpm_limit, rpm_limit)
 
-        # 获取批量大小 (和翻译一样使用lines_limit)
-        lines_limit = self.config.get("lines_limit", 30)
-        pre_line_counts = self.config.get("pre_line_counts", 3)
+        # 获取AI校对批量大小与上下文行数
+        lines_limit = self.config.get("proofread_batch_size", self.config.get("lines_limit", 30))
+        pre_line_counts = self.config.get("proofread_context_lines", self.config.get("pre_line_counts", 3))
+        try:
+            lines_limit = max(1, int(lines_limit))
+        except (TypeError, ValueError):
+            lines_limit = 30
+        try:
+            pre_line_counts = max(0, int(pre_line_counts))
+        except (TypeError, ValueError):
+            pre_line_counts = 3
 
         # 分割数据为批次
         chunks = []
@@ -271,7 +287,8 @@ class AIProofreadMenu:
                                 ai_check={
                                     "has_issues": True,
                                     "issues": issue_list,
-                                    "corrected_translation": corrections.get(line_id, "")
+                                    "corrected_translation": corrections.get(line_id, ""),
+                                    "target_field": item.get("target_field", "translated_text"),
                                 }
                             )
                             report.add_item(report_item)
@@ -419,9 +436,23 @@ class AIProofreadMenu:
                 for cache_file in project.files.values():
                     for cache_item in cache_file.items:
                         if cache_item.text_index == text_index:
-                            # 更新译文
-                            cache_item.translated_text = corrected_text
-                            cache_item.translation_status = TranslationStatus.AI_PROOFREAD
+                            target_field = item.ai_check.get("target_field")
+                            if target_field not in ("translated_text", "polished_text"):
+                                target_field = "polished_text" if cache_item.polished_text.strip() else "translated_text"
+
+                            if target_field == "polished_text":
+                                cache_item.polished_text = corrected_text
+                                cache_item.translation_status = TranslationStatus.POLISHED
+                            else:
+                                cache_item.translated_text = corrected_text
+                                cache_item.translation_status = TranslationStatus.TRANSLATED
+
+                            if cache_item.extra is None:
+                                cache_item.extra = {}
+                            cache_item.extra["ai_proofread"] = {
+                                "target_field": target_field,
+                                "applied": True,
+                            }
                             applied_count += 1
                             break
 

--- a/ModuleFolders/UserInterface/ExportFlow.py
+++ b/ModuleFolders/UserInterface/ExportFlow.py
@@ -65,13 +65,8 @@ class ExportFlow:
                     "bilingual_suffix": "_bilingual",
                     "bilingual_order": config.bilingual_text_order,
                 }
-                source_project = (
-                    self.host.cache_manager.project
-                    if hasattr(self.host.cache_manager, "project") and self.host.cache_manager.project
-                    else project
-                )
                 self.host.file_outputer.output_translated_content(
-                    source_project,
+                    project,
                     output_path,
                     target_path,
                     output_config,

--- a/ModuleFolders/UserInterface/ExportFlow.py
+++ b/ModuleFolders/UserInterface/ExportFlow.py
@@ -23,6 +23,23 @@ class ExportFlow:
     def i18n(self):
         return self.host.i18n
 
+    @staticmethod
+    def _is_proofread_cache(cache_path):
+        return os.path.basename(cache_path) == "AinieeCacheData_proofread.json"
+
+    @staticmethod
+    def _normalize_ai_proofread_status_for_export(project):
+        """兼容旧版AI校对缓存，避免AI_PROOFREAD状态被部分Writer跳过。"""
+        from ModuleFolders.Infrastructure.Cache.CacheItem import TranslationStatus
+
+        for item in project.items_iter():
+            if item.translation_status != TranslationStatus.AI_PROOFREAD:
+                continue
+            if item.polished_text and item.polished_text.strip():
+                item.translation_status = TranslationStatus.POLISHED
+            elif item.translated_text and item.translated_text.strip():
+                item.translation_status = TranslationStatus.TRANSLATED
+
     def run_export_only(self, target_path=None, non_interactive=False):
         from ModuleFolders.Infrastructure.Cache.CacheManager import CacheManager
 
@@ -60,6 +77,8 @@ class ExportFlow:
                 if hasattr(self.host.cache_manager, "flush_pending_save"):
                     self.host.cache_manager.flush_pending_save()
                 project = CacheManager.read_from_file(cache_path)
+                if self._is_proofread_cache(cache_path):
+                    self._normalize_ai_proofread_status_for_export(project)
                 self.host.task_executor.config.initialize(self.host.config)
                 config = self.host.task_executor.config
                 output_config = {

--- a/ModuleFolders/UserInterface/ExportFlow.py
+++ b/ModuleFolders/UserInterface/ExportFlow.py
@@ -35,10 +35,11 @@ class ExportFlow:
         for item in project.items_iter():
             if item.translation_status != TranslationStatus.AI_PROOFREAD:
                 continue
-            if item.polished_text and item.polished_text.strip():
-                item.translation_status = TranslationStatus.POLISHED
-            elif item.translated_text and item.translated_text.strip():
+            if item.translated_text and item.translated_text.strip():
+                item.polished_text = ""
                 item.translation_status = TranslationStatus.TRANSLATED
+            elif item.polished_text and item.polished_text.strip():
+                item.translation_status = TranslationStatus.POLISHED
 
     def run_export_only(self, target_path=None, non_interactive=False):
         from ModuleFolders.Infrastructure.Cache.CacheManager import CacheManager

--- a/ModuleFolders/UserInterface/ExportFlow.py
+++ b/ModuleFolders/UserInterface/ExportFlow.py
@@ -57,6 +57,8 @@ class ExportFlow:
 
         try:
             with console.status(f"[cyan]{self.i18n.get('msg_export_started')}[/cyan]"):
+                if hasattr(self.host.cache_manager, "flush_pending_save"):
+                    self.host.cache_manager.flush_pending_save()
                 project = CacheManager.read_from_file(cache_path)
                 self.host.task_executor.config.initialize(self.host.config)
                 config = self.host.task_executor.config


### PR DESCRIPTION
您好，感谢您维护 AiNiee-Next，这个项目很好用，也祝您五一快乐。

这个 PR 主要修复 AI 校对流程里的几个小问题，尽量保持改动范围小，避免影响现有翻译/润色主流程。

## 修改内容

- AI 校对待检查文本时，如果条目已经润色，优先校对 `polished_text`，否则校对 `translated_text`。
- AI 校对应用修正时，按校对来源写回对应字段：润色稿写回 `polished_text`，初译写回 `translated_text`。
- 应用 AI 校对修正后保持 `TRANSLATED` / `POLISHED` 状态，避免部分导出器只识别这两个状态时跳过已校对内容；AI 校对信息记录到 `extra["ai_proofread"]`。
- 让已有的 `proofread_batch_size` 和 `proofread_context_lines` 配置在 AI 校对批处理里实际生效。
- 导出时使用用户实际选择的 cache 文件，避免选择 `AinieeCacheData_proofread.json` 后仍可能使用内存中的原始项目数据。

## 原因

目前 AI 校对在润色完成后可能仍优先检查初译文本；应用校对修正时也总是写回 `translated_text`，对润色稿场景不太一致。另外，校对版本 cache 被选中后，导出流程仍可能使用当前内存中的项目对象，导致选择校对版本没有真正生效。

## 验证

- `conda run -n lab python -m py_compile ModuleFolders/UserInterface/AIProofreadMenu.py ModuleFolders/UserInterface/ExportFlow.py`
- `git diff --check`