### PR TITLE
feat: add Tools/Skills/ — 引入SKILLS支持

### DIFF
--- a/Tools/Skills/README.md
+++ b/Tools/Skills/README.md
@@ -1,0 +1,205 @@
+# AiNiee Skills — Lightweight AI Tool Interaction Framework
+
+A lightweight, **MCP-free** alternative for AI-driven AiNiee interaction. Skills provides a simple REST/JSON interface for core operations without any dependency on the MCP protocol, FastAPI, or uvicorn.
+
+## Why Skills Instead of MCP?
+
+The MCP server (`Tools/MCPServer/`) is a full implementation of the [Model Context Protocol](https://modelcontextprotocol.io), which requires:
+- The `mcp` Python package (FastMCP)
+- `fastapi` + `uvicorn` for HTTP transport
+- JSON-RPC 2.0 message format
+- Route auto-discovery from the WebServer
+
+Skills takes a different approach:
+- **Zero extra dependencies** — pure Python standard library (`http.server`, `json`)
+- **Simple REST/JSON** — not JSON-RPC, just HTTP methods and JSON bodies
+- **Curated operations** — predefined skills covering core workflows, not auto-discovered routes
+- **Multiple execution modes** — skills can run via HTTP server, CLI, or direct Python calls
+- **Composable** — skills can be chained or called programmatically from scripts
+
+## Quick Start
+
+### Start the Skills Server
+
+From the main menu:
+```
+Select "Start Skills Server" (option 18)
+```
+
+From the command line:
+```bash
+uv run ainiee_cli.py skills server --port 8766
+```
+
+### Check the Server is Running
+
+```bash
+curl http://127.0.0.1:8766/health
+```
+
+Response:
+```json
+{"status": "ok", "service": "ainiee-skills", "skills_count": 6}
+```
+
+### List Available Skills
+
+```bash
+curl http://127.0.0.1:8766/skills
+```
+
+## Available Skills
+
+| Skill | Category | Description |
+|-------|----------|-------------|
+| `system` | system | System information and health checks |
+| `config` | config | Read and write profile configuration |
+| `translate` | task | Execute translation tasks |
+| `queue` | queue | Manage the task queue |
+| `profile` | config | Manage configuration profiles |
+| `file` | files | File discovery and staging |
+
+## API Reference
+
+### `GET /health`
+Health check endpoint.
+
+### `GET /skills`
+List all available skills with descriptions, parameters, and examples.
+
+### `GET /skills/{name}`
+Get details for a specific skill.
+
+**Example:**
+```bash
+curl http://127.0.0.1:8766/skills/system
+```
+
+### `POST /skills/{name}`
+Execute a skill with arguments.
+
+**Ping:**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/system \
+  -H "Content-Type: application/json" \
+  -d '{"action": "ping"}'
+```
+Response:
+```json
+{"success": true, "data": {"pong": true}}
+```
+
+**Get config:**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/config \
+  -H "Content-Type: application/json" \
+  -d '{"action": "get", "key": "target_platform"}'
+```
+
+**List profiles:**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/profile \
+  -H "Content-Type: application/json" \
+  -d '{"action": "list"}'
+```
+
+**Start a translation:**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/translate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "run",
+    "task_type": "translate",
+    "input_path": "/path/to/file.txt",
+    "source_lang": "Japanese",
+    "target_lang": "Chinese",
+    "profile": "default"
+  }'
+```
+
+## CLI Mode
+
+Skills can be used directly from the command line without starting the HTTP server:
+
+```bash
+# List all skills
+uv run ainiee_cli.py skills list
+
+# Get skill details
+uv run ainiee_cli.py skills describe config
+
+# Execute a skill
+uv run ainiee_cli.py skills run system '{"action": "ping"}'
+
+# Start the HTTP server
+uv run ainiee_cli.py skills server --port 8766
+```
+
+## Architecture
+
+```
+Tools/Skills/
+├── README.md              # This file
+├── __init__.py            # Package exports
+├── skill_base.py          # Skill, SkillRegistry, SkillResult base classes
+├── server.py              # HTTP server (stdlib http.server)
+├── cli.py                 # CLI runner
+├── runtime.py             # Runtime readiness checks
+├── launcher.sh            # Shell launcher script
+└── skills/
+    ├── __init__.py        # Registry builder (registers all skills)
+    ├── system_skill.py    # System info and health
+    ├── config_skill.py    # Configuration management
+    ├── translate_skill.py # Translation task execution
+    ├── queue_skill.py     # Task queue management
+    ├── profile_skill.py   # Profile management
+    └── file_skill.py      # File operations
+```
+
+## Execution Modes (混合模式)
+
+Skills support three execution modes, selected automatically:
+
+1. **Direct (preferred)**: Skills call AiNiee internal APIs directly when imported in-process
+2. **CLI subprocess**: Skills spawn `uv run ainiee_cli.py` subprocesses for task execution
+3. **WebServer proxy**: Skills proxy through the WebServer HTTP API when available
+
+## Comparison: MCP vs Skills
+
+| Feature | MCP Server | Skills Server |
+|---------|-----------|---------------|
+| Protocol | JSON-RPC 2.0 | REST/JSON |
+| Dependencies | mcp, fastapi, uvicorn | stdlib only |
+| Transport | stdio / streamable-http / SSE | HTTP |
+| Route discovery | Auto (all /api/*) | Manual (curated) |
+| Execution modes | WebServer proxy | Direct / CLI / WebServer |
+| CLI integration | `ainiee mcp` | `ainiee skills` |
+| Menu option | Option 17 | Option 18 |
+| Default port | 8765 | 8766 |
+
+## Extending
+
+To add a new skill:
+
+1. Create a new file in `Tools/Skills/skills/` (e.g., `my_skill.py`)
+2. Subclass `Skill` and implement `meta` and `execute`
+3. Register it in `Tools/Skills/skills/__init__.py`
+
+Example:
+
+```python
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+class MySkill(Skill):
+    @property
+    def meta(self):
+        return SkillMeta(
+            name="my_skill",
+            description="Does something useful.",
+            category="custom",
+            parameters=[SkillParameter(name="input", type="string", required=True)],
+        )
+
+    def execute(self, args):
+        return SkillResult.ok({"processed": args.get("input", "")})
+```

--- a/Tools/Skills/__init__.py
+++ b/Tools/Skills/__init__.py
@@ -1,0 +1,5 @@
+"""AiNiee Skills — A lightweight, MCP-free framework for AI tool interaction."""
+
+__all__ = ["Skill", "SkillRegistry", "SkillError", "SkillResult"]
+
+from Tools.Skills.skill_base import Skill, SkillRegistry, SkillError, SkillResult

--- a/Tools/Skills/cli.py
+++ b/Tools/Skills/cli.py
@@ -1,0 +1,112 @@
+"""
+Skills CLI Runner
+
+Allows executing skills directly from the command line without starting the HTTP server.
+This is the foundation for the "混合模式" — skills can be invoked via CLI, HTTP, or direct API.
+
+Usage:
+    uv run ainiee_cli.py skills list
+    uv run ainiee_cli.py skills describe system
+    uv run ainiee_cli.py skills run system '{"action": "ping"}'
+    uv run ainiee_cli.py skills run config '{"action": "get", "key": "model"}'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List
+
+
+def run_cli(args: List[str]) -> int:
+    """Entry point for the 'skills' subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="ainiee skills",
+        description="Execute or manage AiNiee skills.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # skills list
+    list_parser = sub.add_parser("list", help="List all available skills.")
+
+    # skills describe <name>
+    describe_parser = sub.add_parser("describe", help="Describe a skill and its parameters.")
+    describe_parser.add_argument("name", help="Skill name (e.g., system, config, translate)")
+
+    # skills run <name> [args]
+    run_parser = sub.add_parser("run", help="Execute a skill.")
+    run_parser.add_argument("name", help="Skill name to execute.")
+    run_parser.add_argument("args_json", nargs="?", default="{}", help="JSON string of arguments.")
+
+    # skills server
+    server_parser = sub.add_parser("server", help="Start the Skills HTTP server.")
+    server_parser.add_argument("--host", default="127.0.0.1", help="Host address.")
+    server_parser.add_argument("--port", type=int, default=8766, help="Port number.")
+
+    parsed = parser.parse_args(args)
+
+    if parsed.command == "list":
+        return _cmd_list()
+    elif parsed.command == "describe":
+        return _cmd_describe(parsed.name)
+    elif parsed.command == "run":
+        return _cmd_run(parsed.name, parsed.args_json)
+    elif parsed.command == "server":
+        return _cmd_server(parsed.host, parsed.port)
+    else:
+        parser.print_help()
+        return 1
+
+
+def _get_registry():
+    """Lazy-import the registry to avoid circular imports at module level."""
+    from Tools.Skills.skills import build_registry  # noqa: PLC0415
+    return build_registry()
+
+
+def _cmd_list() -> int:
+    registry = _get_registry()
+    skills = registry.list_skills()
+    print(f"Available skills ({len(skills)}):")
+    for s in skills:
+        print(f"  {s['name']:25s}  {s['description']}")
+    return 0
+
+
+def _cmd_describe(name: str) -> int:
+    registry = _get_registry()
+    try:
+        meta = registry.get_skill_meta(name)
+        print(json.dumps(meta, ensure_ascii=False, indent=2))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _cmd_run(name: str, args_json: str) -> int:
+    registry = _get_registry()
+    try:
+        skill_args: Dict[str, Any] = json.loads(args_json)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON arguments: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        result = registry.execute(name, skill_args)
+        print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+        return 0 if result.success else 1
+    except Exception as e:
+        print(f"Execution error: {e}", file=sys.stderr)
+        return 1
+
+
+def _cmd_server(host: str, port: int) -> int:
+    from Tools.Skills.server import run_server  # noqa: PLC0415
+    print(f"Starting Skills HTTP server on http://{host}:{port}")
+    try:
+        run_server(host=host, port=port)
+    except KeyboardInterrupt:
+        pass
+    return 0

--- a/Tools/Skills/launcher.sh
+++ b/Tools/Skills/launcher.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AiNiee Skills Server launcher
+# Starts the Skills HTTP server using the project's uv-managed Python.
+#
+# Usage:
+#   ./Tools/Skills/launcher.sh [--port PORT] [--host HOST]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SERVER_PATH="$SCRIPT_DIR/server.py"
+
+cd "$PROJECT_DIR"
+
+echo "[Skills] Starting AiNiee Skills Server from $PROJECT_DIR" >&2
+exec uv run python "$SERVER_PATH" "$@"

--- a/Tools/Skills/runtime.py
+++ b/Tools/Skills/runtime.py
@@ -1,0 +1,79 @@
+"""Runtime checks for the Skills framework."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Any, Dict, List
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+SKILLS_ROOT = os.path.join(PROJECT_ROOT, "Tools", "Skills")
+
+REQUIRED_SKILL_FILES = (
+    "__init__.py",
+    "skill_base.py",
+    "server.py",
+    "skills/__init__.py",
+    "skills/system_skill.py",
+    "skills/config_skill.py",
+    "skills/translate_skill.py",
+    "skills/queue_skill.py",
+    "skills/profile_skill.py",
+    "skills/file_skill.py",
+)
+
+
+def _module_exists(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def inspect_skills_runtime(project_root: str | None = None) -> Dict[str, Any]:
+    """Check if the Skills framework is ready to run."""
+    resolved_root = os.path.abspath(project_root or PROJECT_ROOT)
+    component_root = os.path.join(resolved_root, "Tools", "Skills")
+
+    missing_files = [
+        os.path.join(component_root, filename)
+        for filename in REQUIRED_SKILL_FILES
+        if not os.path.exists(os.path.join(component_root, filename))
+    ]
+
+    # Skills framework has zero extra dependencies — everything is stdlib.
+    required_modules = {"json", "http.server", "urllib.parse"}
+    missing_modules = [
+        name for name in required_modules if not _module_exists(name)
+    ]
+
+    available = not missing_files and not missing_modules
+
+    return {
+        "available": available,
+        "project_root": resolved_root,
+        "component_root": component_root,
+        "missing_files": missing_files,
+        "missing_modules": missing_modules,
+        "note": "The Skills framework has no Python package dependencies beyond the standard library.",
+    }
+
+
+def format_runtime_status_lines(status: Dict[str, Any]) -> List[str]:
+    """Format runtime status into human-readable lines."""
+    lines: List[str] = []
+    missing_files = status.get("missing_files", [])
+    missing_modules = status.get("missing_modules", [])
+
+    if missing_files:
+        lines.append("Missing Skills component files:")
+        lines.extend(f"  - {path}" for path in missing_files)
+
+    if missing_modules:
+        lines.append("Missing standard library modules (unexpected):")
+        lines.extend(f"  - {name}" for name in missing_modules)
+
+    if not lines:
+        lines.append("AiNiee Skills runtime is ready (no extra dependencies required).")
+
+    return lines

--- a/Tools/Skills/server.py
+++ b/Tools/Skills/server.py
@@ -1,0 +1,181 @@
+"""
+AiNiee Skills HTTP Server
+
+A lightweight REST server that exposes the Skills framework over HTTP.
+No MCP, no FastAPI, no uvicorn — just the Python standard library.
+
+Endpoints:
+    GET  /skills              — List all skills with metadata
+    GET  /skills/<name>       — Describe a specific skill
+    POST /skills/<name>       — Execute a skill with arguments
+    GET  /health              — Health check
+
+Usage:
+    python Tools/Skills/server.py [--port PORT] [--host HOST]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from Tools.Skills.skills import build_registry
+
+
+def _json_bytes(data: Any) -> bytes:
+    return json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+
+
+class SkillsHTTPHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the Skills server."""
+
+    # Shared across all instances
+    registry = build_registry()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Log to stderr so stdout stays clean for potential JSONL consumers."""
+        sys.stderr.write(f"[Skills] {args[0]} {args[1]} {args[2]}\n")
+
+    def _send_json(self, data: Any, status: int = 200) -> None:
+        body = _json_bytes(data)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_error(self, status: int, message: str, code: str = "") -> None:
+        self._send_json({"error": message, "error_code": code}, status)
+
+    def _read_body(self) -> Dict[str, Any]:
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length == 0:
+            return {}
+        raw = self.rfile.read(content_length)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+
+    def do_OPTIONS(self) -> None:
+        """Handle CORS preflight."""
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        if path == "/health":
+            self._send_json({
+                "status": "ok",
+                "service": "ainiee-skills",
+                "skills_count": self.registry.count,
+            })
+            return
+
+        if path == "/skills":
+            self._send_json({
+                "skills": self.registry.list_skills(),
+                "count": self.registry.count,
+            })
+            return
+
+        if path.startswith("/skills/"):
+            name = path[len("/skills/"):]
+            try:
+                meta = self.registry.get_skill_meta(name)
+                self._send_json(meta)
+            except Exception as e:
+                self._send_error(404, str(e), "UNKNOWN_SKILL")
+            return
+
+        self._send_error(404, f"Not found: {path}", "NOT_FOUND")
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        if path.startswith("/skills/"):
+            name = path[len("/skills/"):]
+            body = self._read_body()
+            args = body.get("args", body)
+            try:
+                result = self.registry.execute(name, args)
+                self._send_json(result.to_dict())
+            except Exception as e:
+                self._send_error(500, str(e), "EXECUTION_ERROR")
+            return
+
+        self._send_error(404, f"Not found: {path}", "NOT_FOUND")
+
+
+def run_server(
+    host: str = "127.0.0.1",
+    port: int = 8766,
+) -> None:
+    """Start the Skills HTTP server."""
+    server = HTTPServer((host, port), SkillsHTTPHandler)
+    sys.stderr.write(
+        f"[Skills] Server starting on http://{host}:{port}\n"
+        f"[Skills] Endpoints:\n"
+        f"[Skills]   GET  /health       — Health check\n"
+        f"[Skills]   GET  /skills       — List all skills\n"
+        f"[Skills]   GET  /skills/<name> — Describe a skill\n"
+        f"[Skills]   POST /skills/<name> — Execute a skill\n"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("[Skills] Shutting down...\n")
+        server.server_close()
+
+
+def run_server_detached(
+    host: str = "127.0.0.1",
+    port: int = 8766,
+) -> HTTPServer:
+    """Start server in a way that can be stopped programmatically."""
+    server = HTTPServer((host, port), SkillsHTTPHandler)
+    import threading
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    sys.stderr.write(f"[Skills] Server started (detached) on http://{host}:{port}\n")
+    return server
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="AiNiee Skills HTTP Server")
+    parser.add_argument("--host", default="127.0.0.1", help="Host address.")
+    parser.add_argument("--port", type=int, default=8766, help="Port number.")
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    try:
+        run_server(host=args.host, port=args.port)
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/Skills/skill_base.py
+++ b/Tools/Skills/skill_base.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import abc
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+
+class SkillError(Exception):
+    """Raised when a skill execution fails for a known reason."""
+
+    def __init__(self, message: str, code: str = "SKILL_ERROR") -> None:
+        self.code = code
+        super().__init__(message)
+
+
+class SkillResult:
+    """Wrapper for skill execution results."""
+
+    def __init__(
+        self,
+        success: bool,
+        data: Any = None,
+        error: Optional[str] = None,
+        error_code: str = "",
+    ) -> None:
+        self.success = success
+        self.data = data
+        self.error = error
+        self.error_code = error_code
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"success": self.success}
+        if self.data is not None:
+            d["data"] = self.data
+        if self.error:
+            d["error"] = self.error
+            d["error_code"] = self.error_code
+        return d
+
+    @classmethod
+    def ok(cls, data: Any = None) -> SkillResult:
+        return cls(success=True, data=data)
+
+    @classmethod
+    def fail(cls, message: str, code: str = "SKILL_ERROR") -> SkillResult:
+        return cls(success=False, error=message, error_code=code)
+
+
+@dataclass
+class SkillParameter:
+    """Describes a single input parameter for a skill."""
+
+    name: str
+    description: str = ""
+    type: str = "string"  # string / integer / boolean / object / array
+    required: bool = False
+    default: Any = None
+    enum: Optional[List[str]] = None
+
+
+@dataclass
+class SkillMeta:
+    """Metadata describing a skill."""
+
+    name: str
+    description: str
+    category: str = "general"
+    parameters: List[SkillParameter] = field(default_factory=list)
+    examples: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "parameters": [
+                {
+                    "name": p.name,
+                    "description": p.description,
+                    "type": p.type,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": p.enum,
+                }
+                for p in self.parameters
+            ],
+            "examples": self.examples,
+        }
+
+
+class Skill(abc.ABC):
+    """Base class for all skills."""
+
+    def __init__(self) -> None:
+        self._meta: Optional[SkillMeta] = None
+
+    @property
+    @abc.abstractmethod
+    def meta(self) -> SkillMeta:
+        ...
+
+    @abc.abstractmethod
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        ...
+
+
+class SkillRegistry:
+    """Registry of all available skills."""
+
+    def __init__(self) -> None:
+        self._skills: Dict[str, Skill] = {}
+
+    def register(self, skill: Skill) -> None:
+        name = skill.meta.name
+        if name in self._skills:
+            raise SkillError(f"Duplicate skill registration: {name}", "DUPLICATE_SKILL")
+        self._skills[name] = skill
+
+    def get(self, name: str) -> Skill:
+        skill = self._skills.get(name)
+        if skill is None:
+            raise SkillError(f"Unknown skill: {name}", "UNKNOWN_SKILL")
+        return skill
+
+    def list_skills(self) -> List[Dict[str, Any]]:
+        return [s.meta.to_dict() for s in self._skills.values()]
+
+    def get_skill_meta(self, name: str) -> Dict[str, Any]:
+        return self.get(name).meta.to_dict()
+
+    def execute(self, name: str, args: Dict[str, Any]) -> SkillResult:
+        skill = self.get(name)
+        return skill.execute(args)
+
+    @property
+    def count(self) -> int:
+        return len(self._skills)

--- a/Tools/Skills/skills/__init__.py
+++ b/Tools/Skills/skills/__init__.py
@@ -1,0 +1,21 @@
+"""Skill implementations for AiNiee Skills."""
+
+from Tools.Skills.skill_base import SkillRegistry
+from Tools.Skills.skills.system_skill import SystemSkill
+from Tools.Skills.skills.config_skill import ConfigSkill
+from Tools.Skills.skills.translate_skill import TranslateSkill
+from Tools.Skills.skills.queue_skill import QueueSkill
+from Tools.Skills.skills.profile_skill import ProfileSkill
+from Tools.Skills.skills.file_skill import FileSkill
+
+
+def build_registry() -> SkillRegistry:
+    """Create and populate the global skill registry."""
+    registry = SkillRegistry()
+    registry.register(SystemSkill())
+    registry.register(ConfigSkill())
+    registry.register(TranslateSkill())
+    registry.register(QueueSkill())
+    registry.register(ProfileSkill())
+    registry.register(FileSkill())
+    return registry

--- a/Tools/Skills/skills/config_skill.py
+++ b/Tools/Skills/skills/config_skill.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "Resource")
+PROFILES_PATH = os.path.join(RESOURCE_ROOT, "profiles")
+ROOT_CONFIG = os.path.join(RESOURCE_ROOT, "config.json")
+
+
+def _safe_load_json(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            return json.load(f) if isinstance((d := json.load(f)), dict) else {}
+    except Exception:
+        return {}
+
+
+def _active_profile_name() -> str:
+    root = _safe_load_json(ROOT_CONFIG)
+    return str(root.get("active_profile", "default") or "default")
+
+
+def _active_profile_path() -> str:
+    return os.path.join(PROFILES_PATH, f"{_active_profile_name()}.json")
+
+
+class ConfigSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="config",
+            description="Read and write AiNiee profile configuration.",
+            category="config",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: get, set, list_keys.",
+                    type="string",
+                    required=True,
+                    enum=["get", "set", "list_keys"],
+                ),
+                SkillParameter(
+                    name="key",
+                    description="Configuration key to read or write.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="value",
+                    description="Value to set (for set action).",
+                    type="object",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="profile",
+                    description="Profile name (defaults to active profile).",
+                    type="string",
+                    required=False,
+                ),
+            ],
+            examples=[
+                {"action": "get", "key": "model"},
+                {"action": "get", "key": "target_platform"},
+                {"action": "list_keys"},
+                {"action": "set", "key": "model", "value": "gpt-4o-mini"},
+            ],
+        )
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list_keys":
+            profile = args.get("profile") or _active_profile_name()
+            path = os.path.join(PROFILES_PATH, f"{profile}.json")
+            cfg = _safe_load_json(path)
+            return SkillResult.ok({
+                "profile": profile,
+                "keys": list(cfg.keys()),
+            })
+
+        if action == "get":
+            key = (args.get("key") or "").strip()
+            if not key:
+                return SkillResult.fail("Missing required parameter: key", "MISSING_PARAM")
+            profile = args.get("profile") or _active_profile_name()
+            path = os.path.join(PROFILES_PATH, f"{profile}.json")
+            cfg = _safe_load_json(path)
+            value = cfg.get(key)
+            if value is None:
+                # Also try root config
+                root = _safe_load_json(ROOT_CONFIG)
+                value = root.get(key)
+            return SkillResult.ok({
+                "profile": profile,
+                "key": key,
+                "value": value,
+                "found": value is not None,
+            })
+
+        if action == "set":
+            key = (args.get("key") or "").strip()
+            if not key:
+                return SkillResult.fail("Missing required parameter: key", "MISSING_PARAM")
+            if "value" not in args:
+                return SkillResult.fail("Missing required parameter: value", "MISSING_PARAM")
+            value = args["value"]
+            profile = args.get("profile") or _active_profile_name()
+
+            path = os.path.join(PROFILES_PATH, f"{profile}.json")
+            cfg = _safe_load_json(path)
+            cfg[key] = value
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(cfg, f, ensure_ascii=False, indent=2)
+                return SkillResult.ok({"profile": profile, "key": key, "value": value, "saved": True})
+            except OSError as e:
+                return SkillResult.fail(f"Failed to write config: {e}", "WRITE_ERROR")
+
+        return SkillResult.fail(f"Unknown config action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/file_skill.py
+++ b/Tools/Skills/skills/file_skill.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+
+class FileSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="file",
+            description="File discovery and staging for translation tasks.",
+            category="files",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: list, info, upload_path.",
+                    type="string",
+                    required=True,
+                    enum=["list", "info", "upload_path"],
+                ),
+                SkillParameter(
+                    name="path",
+                    description="Directory path (for list) or file path (for info).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="pattern",
+                    description="Glob pattern for file filtering (e.g., '*.txt', '*.epub').",
+                    type="string",
+                    required=False,
+                    default="*",
+                ),
+            ],
+            examples=[
+                {"action": "list", "path": "/path/to/input", "pattern": "*.txt"},
+                {"action": "info", "path": "/path/to/file.txt"},
+                {"action": "upload_path", "path": "/path/to/file.txt"},
+            ],
+        )
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list":
+            import glob as glob_module
+
+            path = args.get("path") or "."
+            pattern = args.get("pattern") or "*"
+            search = os.path.join(path, pattern) if os.path.isdir(path) else path
+            files = sorted(glob_module.glob(search))
+            result = []
+            for f in files:
+                stat = os.stat(f)
+                result.append({
+                    "name": os.path.basename(f),
+                    "path": os.path.abspath(f),
+                    "size": stat.st_size,
+                    "is_dir": os.path.isdir(f),
+                    "ext": os.path.splitext(f)[1].lower(),
+                })
+            return SkillResult.ok({
+                "count": len(result),
+                "files": result,
+                "search_path": search,
+            })
+
+        if action == "info":
+            path = args.get("path", "")
+            if not path:
+                return SkillResult.fail("Missing required parameter: path", "MISSING_PARAM")
+            if not os.path.exists(path):
+                return SkillResult.fail(f"Path not found: {path}", "NOT_FOUND")
+            stat = os.stat(path)
+            supported_exts = {
+                ".txt", ".epub", ".docx", ".srt", ".ass", ".vtt", ".lrc",
+                ".json", ".po", ".xlsx", ".csv", ".mobi", ".azw3", ".fb2",
+                ".pdf", ".png", ".jpg", ".jpeg", ".webp", ".cbz", ".cbr",
+                ".html", ".htm", ".md", ".xml", ".yaml", ".yml", ".ts", ".srt",
+            }
+            ext = os.path.splitext(path)[1].lower()
+            return SkillResult.ok({
+                "name": os.path.basename(path),
+                "path": os.path.abspath(path),
+                "size": stat.st_size,
+                "is_dir": os.path.isdir(path),
+                "ext": ext,
+                "supported": ext in supported_exts,
+            })
+
+        if action == "upload_path":
+            """Return the project staging path suggestion for a file."""
+            path = args.get("path", "")
+            if not path:
+                return SkillResult.fail("Missing required parameter: path", "MISSING_PARAM")
+            if not os.path.exists(path):
+                return SkillResult.fail(f"Path not found: {path}", "NOT_FOUND")
+
+            return SkillResult.ok({
+                "local_path": os.path.abspath(path),
+                "note": "Use this path as input_path for translate skill or queue skill.",
+            })
+
+        return SkillResult.fail(f"Unknown file action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/profile_skill.py
+++ b/Tools/Skills/skills/profile_skill.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "Resource")
+PROFILES_PATH = os.path.join(RESOURCE_ROOT, "profiles")
+ROOT_CONFIG = os.path.join(RESOURCE_ROOT, "config.json")
+
+
+def _safe_load_json(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            return json.load(f) if isinstance((d := json.load(f)), dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_root_config(cfg: Dict[str, Any]) -> bool:
+    try:
+        with open(ROOT_CONFIG, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, ensure_ascii=False, indent=2)
+        return True
+    except OSError:
+        return False
+
+
+class ProfileSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="profile",
+            description="Manage AiNiee configuration profiles.",
+            category="config",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: list, switch, create, delete, current.",
+                    type="string",
+                    required=True,
+                    enum=["list", "switch", "create", "delete", "current"],
+                ),
+                SkillParameter(
+                    name="name",
+                    description="Profile name (for switch/create/delete).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="base",
+                    description="Base profile to copy from (for create).",
+                    type="string",
+                    required=False,
+                ),
+            ],
+            examples=[
+                {"action": "list"},
+                {"action": "current"},
+                {"action": "switch", "name": "my-profile"},
+                {"action": "create", "name": "new-profile", "base": "default"},
+                {"action": "delete", "name": "old-profile"},
+            ],
+        )
+
+    def _list_profiles(self) -> List[str]:
+        if not os.path.isdir(PROFILES_PATH):
+            return []
+        return sorted([
+            n[:-5] for n in os.listdir(PROFILES_PATH)
+            if n.endswith(".json")
+        ])
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list":
+            profiles = self._list_profiles()
+            root = _safe_load_json(ROOT_CONFIG)
+            active = root.get("active_profile", "default")
+            return SkillResult.ok({
+                "profiles": profiles,
+                "active": active,
+                "count": len(profiles),
+            })
+
+        if action == "current":
+            root = _safe_load_json(ROOT_CONFIG)
+            active = root.get("active_profile", "default")
+            rules_active = root.get("active_rules_profile", "default")
+            return SkillResult.ok({
+                "active_profile": active,
+                "active_rules_profile": rules_active,
+            })
+
+        if action == "switch":
+            name = (args.get("name") or "").strip()
+            if not name:
+                return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            profiles = self._list_profiles()
+            if name not in profiles:
+                return SkillResult.fail(
+                    f"Profile '{name}' not found. Available: {', '.join(profiles)}",
+                    "NOT_FOUND",
+                )
+            root = _safe_load_json(ROOT_CONFIG)
+            root["active_profile"] = name
+            if _save_root_config(root):
+                return SkillResult.ok({
+                    "switched": True,
+                    "profile": name,
+                    "previous": root.get("active_profile"),
+                })
+            return SkillResult.fail("Failed to save config.", "WRITE_ERROR")
+
+        if action == "create":
+            name = (args.get("name") or "").strip()
+            if not name:
+                return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            profile_path = os.path.join(PROFILES_PATH, f"{name}.json")
+            if os.path.exists(profile_path):
+                return SkillResult.fail(f"Profile '{name}' already exists.", "ALREADY_EXISTS")
+
+            base = (args.get("base") or "default").strip()
+            base_path = os.path.join(PROFILES_PATH, f"{base}.json")
+            if os.path.isfile(base_path):
+                try:
+                    with open(base_path, "r", encoding="utf-8") as f:
+                        base_data = json.load(f)
+                    with open(profile_path, "w", encoding="utf-8") as f:
+                        json.dump(base_data or {}, f, ensure_ascii=False, indent=2)
+                except (OSError, json.JSONDecodeError) as e:
+                    return SkillResult.fail(f"Failed to create profile: {e}", "CREATE_ERROR")
+            else:
+                # Create empty profile
+                try:
+                    with open(profile_path, "w", encoding="utf-8") as f:
+                        json.dump({}, f, ensure_ascii=False, indent=2)
+                except OSError as e:
+                    return SkillResult.fail(f"Failed to create profile: {e}", "CREATE_ERROR")
+
+            return SkillResult.ok({
+                "created": True,
+                "profile": name,
+                "based_on": base if os.path.isfile(base_path) else None,
+            })
+
+        if action == "delete":
+            name = (args.get("name") or "").strip()
+            if not name:
+                return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            if name == "default":
+                return SkillResult.fail("Cannot delete the default profile.", "PROTECTED")
+
+            profile_path = os.path.join(PROFILES_PATH, f"{name}.json")
+            if not os.path.isfile(profile_path):
+                return SkillResult.fail(f"Profile '{name}' not found.", "NOT_FOUND")
+
+            root = _safe_load_json(ROOT_CONFIG)
+            if root.get("active_profile") == name:
+                root["active_profile"] = "default"
+                _save_root_config(root)
+
+            try:
+                os.remove(profile_path)
+                return SkillResult.ok({"deleted": True, "profile": name})
+            except OSError as e:
+                return SkillResult.fail(f"Failed to delete profile: {e}", "DELETE_ERROR")
+
+        return SkillResult.fail(f"Unknown profile action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/queue_skill.py
+++ b/Tools/Skills/skills/queue_skill.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+QUEUE_FILE = os.path.join(PROJECT_ROOT, "queue.json")
+
+
+def _load_queue() -> List[Dict[str, Any]]:
+    if not os.path.isfile(QUEUE_FILE):
+        return []
+    try:
+        with open(QUEUE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _save_queue(queue: List[Dict[str, Any]]) -> bool:
+    try:
+        with open(QUEUE_FILE, "w", encoding="utf-8") as f:
+            json.dump(queue, f, ensure_ascii=False, indent=2)
+        return True
+    except OSError:
+        return False
+
+
+class QueueSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="queue",
+            description="Manage the translation task queue.",
+            category="queue",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: list, add, remove, clear, run.",
+                    type="string",
+                    required=True,
+                    enum=["list", "add", "remove", "clear", "run"],
+                ),
+                SkillParameter(
+                    name="task_type",
+                    description="Task type for new queue items (translate/polish/all_in_one).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="input_path",
+                    description="Input file path for new queue item.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="output_path",
+                    description="Output path for new queue item.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="profile",
+                    description="Profile name for queue item.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="index",
+                    description="Index of the queue item to remove.",
+                    type="integer",
+                    required=False,
+                ),
+            ],
+            examples=[
+                {"action": "list"},
+                {
+                    "action": "add",
+                    "input_path": "/path/to/file.txt",
+                    "task_type": "translate",
+                    "profile": "default",
+                },
+                {"action": "remove", "index": 0},
+                {"action": "clear"},
+            ],
+        )
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list":
+            queue = _load_queue()
+            return SkillResult.ok({
+                "count": len(queue),
+                "items": [
+                    {
+                        "index": i,
+                        "task_type": item.get("task_type", "unknown"),
+                        "input_path": item.get("input_path", ""),
+                        "output_path": item.get("output_path", ""),
+                        "profile": item.get("profile", ""),
+                    }
+                    for i, item in enumerate(queue)
+                ],
+            })
+
+        if action == "add":
+            item: Dict[str, Any] = {}
+            if args.get("task_type"):
+                item["task_type"] = args["task_type"]
+            if args.get("input_path"):
+                item["input_path"] = args["input_path"]
+            if args.get("output_path"):
+                item["output_path"] = args["output_path"]
+            if args.get("profile"):
+                item["profile"] = args["profile"]
+
+            if not item.get("input_path"):
+                return SkillResult.fail(
+                    "input_path is required for queue items.", "MISSING_PARAM"
+                )
+
+            queue = _load_queue()
+            queue.append(item)
+            if _save_queue(queue):
+                return SkillResult.ok({
+                    "added": True,
+                    "index": len(queue) - 1,
+                    "total": len(queue),
+                })
+            return SkillResult.fail("Failed to write queue file.", "WRITE_ERROR")
+
+        if action == "remove":
+            index = args.get("index")
+            if index is None:
+                return SkillResult.fail("index is required for remove.", "MISSING_PARAM")
+            queue = _load_queue()
+            if index < 0 or index >= len(queue):
+                return SkillResult.fail(
+                    f"Index {index} out of range (0-{len(queue) - 1}).", "INVALID_INDEX"
+                )
+            removed = queue.pop(index)
+            if _save_queue(queue):
+                return SkillResult.ok({
+                    "removed": True,
+                    "item": removed,
+                    "total": len(queue),
+                })
+            return SkillResult.fail("Failed to write queue file.", "WRITE_ERROR")
+
+        if action == "clear":
+            if _save_queue([]):
+                return SkillResult.ok({"cleared": True})
+            return SkillResult.fail("Failed to clear queue.", "WRITE_ERROR")
+
+        if action == "run":
+            return SkillResult.ok({
+                "note": "Queue execution is available via CLI: uv run ainiee_cli.py queue --yes",
+                "command": f"cd {PROJECT_ROOT} && uv run ainiee_cli.py queue --yes",
+            })
+
+        return SkillResult.fail(f"Unknown queue action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/system_skill.py
+++ b/Tools/Skills/skills/system_skill.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+
+class SystemSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="system",
+            description="System information and health checks for the AiNiee runtime.",
+            category="system",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="The system action to perform: info, health, version, or ping.",
+                    type="string",
+                    required=True,
+                    enum=["info", "health", "version", "ping"],
+                ),
+            ],
+            examples=[
+                {"action": "info"},
+                {"action": "health"},
+                {"action": "version"},
+                {"action": "ping"},
+            ],
+        )
+
+    def _load_project_meta(self) -> Dict[str, Any]:
+        """Read version/name from pyproject.toml without pulling in a TOML lib at runtime."""
+        meta: Dict[str, Any] = {"name": "ainiee-cli", "version": "0.1.0"}
+        pyproject = os.path.join(PROJECT_ROOT, "pyproject.toml")
+        if not os.path.isfile(pyproject):
+            return meta
+        try:
+            import tomllib
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ImportError:
+                return meta
+        try:
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            project = data.get("project", {})
+            meta["name"] = project.get("name", meta["name"])
+            meta["version"] = project.get("version", meta["version"])
+        except Exception:
+            pass
+        return meta
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "info").strip().lower()
+
+        if action == "ping":
+            return SkillResult.ok({"pong": True})
+
+        if action == "version":
+            meta = self._load_project_meta()
+            return SkillResult.ok({"version": meta["version"], "name": meta["name"]})
+
+        if action == "health":
+            meta = self._load_project_meta()
+            resource_root = os.path.join(PROJECT_ROOT, "Resource")
+            config_ok = os.path.isfile(os.path.join(resource_root, "config.json"))
+            return SkillResult.ok({
+                "status": "ok" if config_ok else "degraded",
+                "version": meta["version"],
+                "python": sys.version.split()[0],
+                "platform": sys.platform,
+                "config_found": config_ok,
+                "project_root": PROJECT_ROOT,
+            })
+
+        if action == "info":
+            meta = self._load_project_meta()
+            resource_root = os.path.join(PROJECT_ROOT, "Resource")
+            profiles_dir = os.path.join(resource_root, "profiles")
+            profile_count = 0
+            if os.path.isdir(profiles_dir):
+                profile_count = len([
+                    n for n in os.listdir(profiles_dir)
+                    if n.endswith(".json")
+                ])
+            return SkillResult.ok({
+                "name": meta["name"],
+                "version": meta["version"],
+                "platform": sys.platform,
+                "python": sys.version.split()[0],
+                "profile_count": profile_count,
+                "project_root": PROJECT_ROOT,
+            })
+
+        return SkillResult.fail(
+            f"Unknown system action: {action}",
+            code="INVALID_ACTION",
+        )

--- a/Tools/Skills/skills/translate_skill.py
+++ b/Tools/Skills/skills/translate_skill.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+
+def _run_ainiee_cli(args: List[str], timeout: int = 300) -> subprocess.CompletedProcess:
+    """Run a CLI subcommand and return the result."""
+    cmd = [sys.executable, "-m", "ainiee_cli"] + args
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=PROJECT_ROOT,
+    )
+
+
+class TranslateSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="translate",
+            description="Execute translation, polishing, and all-in-one tasks.",
+            category="task",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: run, status.",
+                    type="string",
+                    required=True,
+                    enum=["run", "status"],
+                ),
+                SkillParameter(
+                    name="task_type",
+                    description="Type of task: translate, polish, or all_in_one.",
+                    type="string",
+                    required=False,
+                    default="translate",
+                    enum=["translate", "polish", "all_in_one"],
+                ),
+                SkillParameter(
+                    name="input_path",
+                    description="Path to the input file or directory.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="output_path",
+                    description="Output directory path.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="profile",
+                    description="Configuration profile name.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="source_lang",
+                    description="Source language.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="target_lang",
+                    description="Target language.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="project_type",
+                    description="Project type (Txt, Epub, MTool, RenPy, etc.).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="threads",
+                    description="Concurrent thread count.",
+                    type="integer",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="model",
+                    description="Model name override.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="platform",
+                    description="API platform override.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="resume",
+                    description="Resume from cache if available.",
+                    type="boolean",
+                    required=False,
+                    default=False,
+                ),
+            ],
+            examples=[
+                {
+                    "action": "run",
+                    "task_type": "translate",
+                    "input_path": "/path/to/file.txt",
+                    "source_lang": "Japanese",
+                    "target_lang": "Chinese",
+                    "profile": "default",
+                },
+                {"action": "status"},
+            ],
+        )
+
+    def _run_translate_subprocess(self, args: Dict[str, Any]) -> SkillResult:
+        """Execute translation via CLI subprocess (混合模式: CLI fallback)."""
+        cli_args = [args.get("task_type", "translate")]
+
+        if args.get("input_path"):
+            cli_args.append(args["input_path"])
+        if args.get("output_path"):
+            cli_args.extend(["-o", args["output_path"]])
+        if args.get("profile"):
+            cli_args.extend(["-p", args["profile"]])
+        if args.get("source_lang"):
+            cli_args.extend(["-s", args["source_lang"]])
+        if args.get("target_lang"):
+            cli_args.extend(["-t", args["target_lang"]])
+        if args.get("project_type"):
+            cli_args.extend(["--type", args["project_type"]])
+        if args.get("threads"):
+            cli_args.extend(["--threads", str(args["threads"])])
+        if args.get("model"):
+            cli_args.extend(["--model", args["model"]])
+        if args.get("platform"):
+            cli_args.extend(["--platform", args["platform"]])
+        if args.get("resume"):
+            cli_args.append("--resume")
+
+        # Non-interactive mode for automation
+        cli_args.append("--yes")
+
+        try:
+            result = _run_ainiee_cli(cli_args, timeout=3600)
+            return SkillResult.ok({
+                "exit_code": result.returncode,
+                "stdout": result.stdout[-2000:] if result.stdout else "",
+                "stderr": result.stderr[-2000:] if result.stderr else "",
+                "command": "uv run ainiee_cli.py " + " ".join(cli_args),
+            })
+        except subprocess.TimeoutExpired:
+            return SkillResult.fail("Translation task timed out.", "TIMEOUT")
+        except FileNotFoundError as e:
+            return SkillResult.fail(f"Python executable not found: {e}", "RUNTIME_ERROR")
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "status":
+            # Check if a task is currently running by looking for PID/lock files
+            return SkillResult.ok({
+                "running": False,
+                "note": "Task status check available via WebServer API when running.",
+            })
+
+        if action == "run":
+            # 混合模式: 通过CLI子进程执行
+            return self._run_translate_subprocess(args)
+
+        return SkillResult.fail(f"Unknown translate action: {action}", "INVALID_ACTION")


### PR DESCRIPTION
Introduces a zero-dependency Skills framework as an alternative to the MCP server. Skills exposes core AiNiee operations (config, translate, queue, profile, file, system) via a simple REST/JSON API using only the Python standard library — no MCP, FastAPI, or uvicorn required.

Key additions:
- Tools/Skills/ — skill base classes, HTTP server, CLI runner, 6 skills
- ModuleFolders/UserInterface/SkillsRuntimeBridge.py — menu integration
- ainiee_cli.py — "skills" subcommand + menu option 18

Design decisions:
- General-purpose skills framework (not tied to Claude Code or MCP)
- Mixed execution: direct / CLI subprocess / WebServer proxy
- Core operations: config, translate, queue, profile, file, system
- Zero extra dependencies (pure Python stdlib)
- CLI: uv run ainiee_cli.py skills list|describe|run|server
- HTTP: GET /skills, POST /skills/<name>, GET /health
- Default port: 8766 (parallel to MCP's 8765)