### PR TITLE
feat: 新增 Tools/Skills/ 轻量级 AI 交互框架（MCP 替代方案）

### DIFF
--- a/Tools/Skills/README.md
+++ b/Tools/Skills/README.md
@@ -1,0 +1,201 @@
+# AiNiee Skills — 轻量级 AI 工具调用框架
+
+一套轻量的、**不依赖 MCP** 的 AiNiee 交互框架。Skills 通过简洁的 REST/JSON 接口暴露核心功能，无需 MCP 协议、FastAPI 或 uvicorn。
+
+## 为什么用 Skills 而不是 MCP？
+
+MCP 服务器（`Tools/MCPServer/`）是一套完整的 [Model Context Protocol](https://modelcontextprotocol.io) 实现，需要：
+- `mcp` Python 包（FastMCP）
+- `fastapi` + `uvicorn` 提供 HTTP 传输
+- JSON-RPC 2.0 消息格式
+- 从 WebServer 自动发现路由
+
+Skills 则完全不同：
+- **零额外依赖** — 仅用 Python 标准库（`http.server`、`json`）
+- **简洁 REST/JSON** — 不是 JSON-RPC，就是 HTTP + JSON
+- **精选操作** — 预定义的 skill 覆盖核心工作流，不自动暴露所有路由
+- **多种执行模式** — 可通过 HTTP 服务、CLI、或直接 Python 调用
+- **可组合** — skill 可串联调用，适合脚本自动化
+
+## 快速开始
+
+### 启动 Skills Server
+
+命令行启动：
+```bash
+python Tools/Skills/server.py --port 8766
+```
+
+或用启动脚本：
+```bash
+bash Tools/Skills/launcher.sh --port 8766
+```
+
+### 检查服务是否运行
+
+```bash
+curl http://127.0.0.1:8766/health
+```
+
+返回：
+```json
+{"status": "ok", "service": "ainiee-skills", "skills_count": 6}
+```
+
+### 查看可用 Skills
+
+```bash
+curl http://127.0.0.1:8766/skills
+```
+
+## 内置 Skills
+
+| Skill | 分类 | 说明 |
+|-------|------|------|
+| `system` | system | 系统信息与健康检查 |
+| `config` | config | 读写配置文件的设置项 |
+| `translate` | task | 执行翻译任务 |
+| `queue` | queue | 管理翻译任务队列 |
+| `profile` | config | 管理配置方案（新建/切换/删除） |
+| `file` | files | 文件发现与暂存 |
+
+## API 参考
+
+### `GET /health`
+健康检查端点。
+
+### `GET /skills`
+列出所有可用的 skill，包含说明、参数和示例。
+
+### `GET /skills/{name}`
+获取指定 skill 的详细信息。
+
+**示例：**
+```bash
+curl http://127.0.0.1:8766/skills/system
+```
+
+### `POST /skills/{name}`
+执行一个 skill，传入参数。
+
+**Ping：**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/system \
+  -H "Content-Type: application/json" \
+  -d '{"action": "ping"}'
+```
+返回：
+```json
+{"success": true, "data": {"pong": true}}
+```
+
+**读取配置：**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/config \
+  -H "Content-Type: application/json" \
+  -d '{"action": "get", "key": "target_platform"}'
+```
+
+**列出配置方案：**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/profile \
+  -H "Content-Type: application/json" \
+  -d '{"action": "list"}'
+```
+
+**启动翻译：**
+```bash
+curl -X POST http://127.0.0.1:8766/skills/translate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "run",
+    "task_type": "translate",
+    "input_path": "/path/to/file.txt",
+    "source_lang": "Japanese",
+    "target_lang": "Chinese",
+    "profile": "default"
+  }'
+```
+
+## CLI 模式
+
+不启动 HTTP 服务也能直接调用 skill：
+
+```bash
+# 列出所有 skill
+python Tools/Skills/cli.py list
+
+# 查看 skill 详情
+python Tools/Skills/cli.py describe config
+
+# 执行 skill
+python Tools/Skills/cli.py run system '{"action": "ping"}'
+
+# 启动 HTTP 服务
+python Tools/Skills/cli.py server --port 8766
+```
+
+## 目录结构
+
+```
+Tools/Skills/
+├── README.md              # 本文档
+├── __init__.py            # 包导出
+├── skill_base.py          # Skill、SkillRegistry、SkillResult 基类
+├── server.py              # HTTP 服务（基于 stdlib http.server）
+├── cli.py                 # CLI 运行器
+├── runtime.py             # 运行环境检查
+├── launcher.sh            # Shell 启动脚本
+└── skills/
+    ├── __init__.py        # 注册中心（注册所有 skill）
+    ├── system_skill.py    # 系统信息与健康检查
+    ├── config_skill.py    # 配置管理
+    ├── translate_skill.py # 翻译任务执行
+    ├── queue_skill.py     # 任务队列管理
+    ├── profile_skill.py   # 配置方案管理
+    └── file_skill.py      # 文件操作
+```
+
+## 执行模式（混合模式）
+
+Skills 支持三种执行模式，自动选择：
+
+1. **直接调用（首选）**：进程内直接调用 AiNiee 内部 API
+2. **CLI 子进程**：通过 `uv run ainiee_cli.py` 子进程执行任务
+3. **WebServer 代理**：通过 WebServer HTTP API 代理调用
+
+## MCP 与 Skills 对比
+
+| 特性 | MCP Server | Skills Server |
+|------|-----------|---------------|
+| 协议 | JSON-RPC 2.0 | REST/JSON |
+| 依赖 | mcp、fastapi、uvicorn | 仅标准库 |
+| 传输层 | stdio / streamable-http / SSE | HTTP |
+| 路由发现 | 自动（全部 /api/*） | 手动精选 |
+| 执行模式 | WebServer 代理 | 直接 / CLI / WebServer |
+| 默认端口 | 8765 | 8766 |
+
+## 扩展：添加新的 Skill
+
+1. 在 `Tools/Skills/skills/` 下新建文件（如 `my_skill.py`）
+2. 继承 `Skill` 基类，实现 `meta` 和 `execute`
+3. 在 `Tools/Skills/skills/__init__.py` 中注册
+
+示例：
+
+```python
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+class MySkill(Skill):
+    @property
+    def meta(self):
+        return SkillMeta(
+            name="my_skill",
+            description="做些有用的事。",
+            category="custom",
+            parameters=[SkillParameter(name="input", type="string", required=True)],
+        )
+
+    def execute(self, args):
+        return SkillResult.ok({"processed": args.get("input", "")})
+```

--- a/Tools/Skills/README.md
+++ b/Tools/Skills/README.md
@@ -11,7 +11,7 @@ MCP 服务器（`Tools/MCPServer/`）是一套完整的 [Model Context Protocol]
 - 从 WebServer 自动发现路由
 
 Skills 则完全不同：
-- **零额外依赖** — 仅用 Python 标准库（`http.server`、`json`）
+- **零额外服务依赖** — HTTP 层仅用 Python 标准库（`http.server`、`json`），业务层复用项目现有模块
 - **简洁 REST/JSON** — 不是 JSON-RPC，就是 HTTP + JSON
 - **精选操作** — 预定义的 skill 覆盖核心工作流，不自动暴露所有路由
 - **多种执行模式** — 可通过 HTTP 服务、CLI、或直接 Python 调用
@@ -25,6 +25,15 @@ Skills 则完全不同：
 ```bash
 python Tools/Skills/server.py --port 8766
 ```
+
+默认情况下，`POST /skills/{name}` 需要鉴权。服务启动时会在终端输出本次运行的
+`X-AiNiee-Skills-Auth` token；也可以用环境变量固定 token：
+
+```bash
+AINIEE_SKILLS_AUTH_TOKEN="your-token" python Tools/Skills/server.py --port 8766
+```
+
+只在可信本机调试时，可以用 `--no-auth` 临时关闭 HTTP 鉴权。
 
 或用启动脚本：
 ```bash
@@ -55,8 +64,8 @@ curl http://127.0.0.1:8766/skills
 | `system` | system | 系统信息与健康检查 |
 | `config` | config | 读写配置文件的设置项 |
 | `translate` | task | 执行翻译任务 |
-| `queue` | queue | 管理翻译任务队列 |
-| `profile` | config | 管理配置方案（新建/切换/删除） |
+| `queue` | queue | 管理项目内置任务队列（`Resource/queue_tasks.json`） |
+| `profile` | config | 管理配置方案（新建/切换/删除，自动限制在 profiles 目录内） |
 | `file` | files | 文件发现与暂存 |
 
 ## API 参考
@@ -82,6 +91,7 @@ curl http://127.0.0.1:8766/skills/system
 ```bash
 curl -X POST http://127.0.0.1:8766/skills/system \
   -H "Content-Type: application/json" \
+  -H "X-AiNiee-Skills-Auth: your-token" \
   -d '{"action": "ping"}'
 ```
 返回：
@@ -93,6 +103,7 @@ curl -X POST http://127.0.0.1:8766/skills/system \
 ```bash
 curl -X POST http://127.0.0.1:8766/skills/config \
   -H "Content-Type: application/json" \
+  -H "X-AiNiee-Skills-Auth: your-token" \
   -d '{"action": "get", "key": "target_platform"}'
 ```
 
@@ -100,6 +111,7 @@ curl -X POST http://127.0.0.1:8766/skills/config \
 ```bash
 curl -X POST http://127.0.0.1:8766/skills/profile \
   -H "Content-Type: application/json" \
+  -H "X-AiNiee-Skills-Auth: your-token" \
   -d '{"action": "list"}'
 ```
 
@@ -107,6 +119,7 @@ curl -X POST http://127.0.0.1:8766/skills/profile \
 ```bash
 curl -X POST http://127.0.0.1:8766/skills/translate \
   -H "Content-Type: application/json" \
+  -H "X-AiNiee-Skills-Auth: your-token" \
   -d '{
     "action": "run",
     "task_type": "translate",

--- a/Tools/Skills/__init__.py
+++ b/Tools/Skills/__init__.py
@@ -1,0 +1,5 @@
+"""AiNiee Skills — A lightweight, MCP-free framework for AI tool interaction."""
+
+__all__ = ["Skill", "SkillRegistry", "SkillError", "SkillResult"]
+
+from Tools.Skills.skill_base import Skill, SkillRegistry, SkillError, SkillResult

--- a/Tools/Skills/cli.py
+++ b/Tools/Skills/cli.py
@@ -1,0 +1,112 @@
+"""
+Skills CLI Runner
+
+Allows executing skills directly from the command line without starting the HTTP server.
+This is the foundation for the "混合模式" — skills can be invoked via CLI, HTTP, or direct API.
+
+Usage:
+    uv run ainiee_cli.py skills list
+    uv run ainiee_cli.py skills describe system
+    uv run ainiee_cli.py skills run system '{"action": "ping"}'
+    uv run ainiee_cli.py skills run config '{"action": "get", "key": "model"}'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List
+
+
+def run_cli(args: List[str]) -> int:
+    """Entry point for the 'skills' subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="ainiee skills",
+        description="Execute or manage AiNiee skills.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # skills list
+    list_parser = sub.add_parser("list", help="List all available skills.")
+
+    # skills describe <name>
+    describe_parser = sub.add_parser("describe", help="Describe a skill and its parameters.")
+    describe_parser.add_argument("name", help="Skill name (e.g., system, config, translate)")
+
+    # skills run <name> [args]
+    run_parser = sub.add_parser("run", help="Execute a skill.")
+    run_parser.add_argument("name", help="Skill name to execute.")
+    run_parser.add_argument("args_json", nargs="?", default="{}", help="JSON string of arguments.")
+
+    # skills server
+    server_parser = sub.add_parser("server", help="Start the Skills HTTP server.")
+    server_parser.add_argument("--host", default="127.0.0.1", help="Host address.")
+    server_parser.add_argument("--port", type=int, default=8766, help="Port number.")
+
+    parsed = parser.parse_args(args)
+
+    if parsed.command == "list":
+        return _cmd_list()
+    elif parsed.command == "describe":
+        return _cmd_describe(parsed.name)
+    elif parsed.command == "run":
+        return _cmd_run(parsed.name, parsed.args_json)
+    elif parsed.command == "server":
+        return _cmd_server(parsed.host, parsed.port)
+    else:
+        parser.print_help()
+        return 1
+
+
+def _get_registry():
+    """Lazy-import the registry to avoid circular imports at module level."""
+    from Tools.Skills.skills import build_registry  # noqa: PLC0415
+    return build_registry()
+
+
+def _cmd_list() -> int:
+    registry = _get_registry()
+    skills = registry.list_skills()
+    print(f"Available skills ({len(skills)}):")
+    for s in skills:
+        print(f"  {s['name']:25s}  {s['description']}")
+    return 0
+
+
+def _cmd_describe(name: str) -> int:
+    registry = _get_registry()
+    try:
+        meta = registry.get_skill_meta(name)
+        print(json.dumps(meta, ensure_ascii=False, indent=2))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _cmd_run(name: str, args_json: str) -> int:
+    registry = _get_registry()
+    try:
+        skill_args: Dict[str, Any] = json.loads(args_json)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON arguments: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        result = registry.execute(name, skill_args)
+        print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+        return 0 if result.success else 1
+    except Exception as e:
+        print(f"Execution error: {e}", file=sys.stderr)
+        return 1
+
+
+def _cmd_server(host: str, port: int) -> int:
+    from Tools.Skills.server import run_server  # noqa: PLC0415
+    print(f"Starting Skills HTTP server on http://{host}:{port}")
+    try:
+        run_server(host=host, port=port)
+    except KeyboardInterrupt:
+        pass
+    return 0

--- a/Tools/Skills/cli.py
+++ b/Tools/Skills/cli.py
@@ -5,24 +5,32 @@ Allows executing skills directly from the command line without starting the HTTP
 This is the foundation for the "混合模式" — skills can be invoked via CLI, HTTP, or direct API.
 
 Usage:
-    uv run ainiee_cli.py skills list
-    uv run ainiee_cli.py skills describe system
-    uv run ainiee_cli.py skills run system '{"action": "ping"}'
-    uv run ainiee_cli.py skills run config '{"action": "get", "key": "model"}'
+    python Tools/Skills/cli.py list
+    python Tools/Skills/cli.py describe system
+    python Tools/Skills/cli.py run system '{"action": "ping"}'
+    python Tools/Skills/cli.py run config '{"action": "get", "key": "model"}'
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from typing import Any, Dict, List
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 
 
 def run_cli(args: List[str]) -> int:
     """Entry point for the 'skills' subcommand."""
     parser = argparse.ArgumentParser(
-        prog="ainiee skills",
+        prog="python Tools/Skills/cli.py",
         description="Execute or manage AiNiee skills.",
     )
     sub = parser.add_subparsers(dest="command")
@@ -43,6 +51,17 @@ def run_cli(args: List[str]) -> int:
     server_parser = sub.add_parser("server", help="Start the Skills HTTP server.")
     server_parser.add_argument("--host", default="127.0.0.1", help="Host address.")
     server_parser.add_argument("--port", type=int, default=8766, help="Port number.")
+    server_parser.add_argument("--auth-token", default=None, help="HTTP auth token.")
+    server_parser.add_argument(
+        "--no-auth",
+        action="store_true",
+        help="Disable HTTP auth. Only use on trusted local machines.",
+    )
+    server_parser.add_argument(
+        "--allow-origin",
+        default="",
+        help="Optional CORS Access-Control-Allow-Origin value.",
+    )
 
     parsed = parser.parse_args(args)
 
@@ -53,7 +72,13 @@ def run_cli(args: List[str]) -> int:
     elif parsed.command == "run":
         return _cmd_run(parsed.name, parsed.args_json)
     elif parsed.command == "server":
-        return _cmd_server(parsed.host, parsed.port)
+        return _cmd_server(
+            parsed.host,
+            parsed.port,
+            auth_token=parsed.auth_token,
+            require_auth=not parsed.no_auth,
+            allow_origin=parsed.allow_origin,
+        )
     else:
         parser.print_help()
         return 1
@@ -102,11 +127,32 @@ def _cmd_run(name: str, args_json: str) -> int:
         return 1
 
 
-def _cmd_server(host: str, port: int) -> int:
+def _cmd_server(
+    host: str,
+    port: int,
+    *,
+    auth_token: str | None = None,
+    require_auth: bool = True,
+    allow_origin: str = "",
+) -> int:
     from Tools.Skills.server import run_server  # noqa: PLC0415
     print(f"Starting Skills HTTP server on http://{host}:{port}")
     try:
-        run_server(host=host, port=port)
+        run_server(
+            host=host,
+            port=port,
+            auth_token=auth_token,
+            require_auth=require_auth,
+            allow_origin=allow_origin,
+        )
     except KeyboardInterrupt:
         pass
     return 0
+
+
+def main() -> int:
+    return run_cli(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/Skills/launcher.sh
+++ b/Tools/Skills/launcher.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AiNiee Skills Server launcher
+# Starts the Skills HTTP server using the project's uv-managed Python.
+#
+# Usage:
+#   ./Tools/Skills/launcher.sh [--port PORT] [--host HOST]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SERVER_PATH="$SCRIPT_DIR/server.py"
+
+cd "$PROJECT_DIR"
+
+echo "[Skills] Starting AiNiee Skills Server from $PROJECT_DIR" >&2
+exec uv run python "$SERVER_PATH" "$@"

--- a/Tools/Skills/runtime.py
+++ b/Tools/Skills/runtime.py
@@ -17,6 +17,7 @@ REQUIRED_SKILL_FILES = (
     "skill_base.py",
     "server.py",
     "skills/__init__.py",
+    "skills/common.py",
     "skills/system_skill.py",
     "skills/config_skill.py",
     "skills/translate_skill.py",
@@ -41,7 +42,7 @@ def inspect_skills_runtime(project_root: str | None = None) -> Dict[str, Any]:
         if not os.path.exists(os.path.join(component_root, filename))
     ]
 
-    # Skills framework has zero extra dependencies — everything is stdlib.
+    # The HTTP layer has no extra server dependencies; business logic reuses project modules.
     required_modules = {"json", "http.server", "urllib.parse"}
     missing_modules = [
         name for name in required_modules if not _module_exists(name)
@@ -55,7 +56,7 @@ def inspect_skills_runtime(project_root: str | None = None) -> Dict[str, Any]:
         "component_root": component_root,
         "missing_files": missing_files,
         "missing_modules": missing_modules,
-        "note": "The Skills framework has no Python package dependencies beyond the standard library.",
+        "note": "The Skills HTTP layer has no server package dependencies beyond the standard library.",
     }
 
 
@@ -74,6 +75,6 @@ def format_runtime_status_lines(status: Dict[str, Any]) -> List[str]:
         lines.extend(f"  - {name}" for name in missing_modules)
 
     if not lines:
-        lines.append("AiNiee Skills runtime is ready (no extra dependencies required).")
+        lines.append("AiNiee Skills runtime is ready (no extra server dependencies required).")
 
     return lines

--- a/Tools/Skills/runtime.py
+++ b/Tools/Skills/runtime.py
@@ -1,0 +1,79 @@
+"""Runtime checks for the Skills framework."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Any, Dict, List
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+SKILLS_ROOT = os.path.join(PROJECT_ROOT, "Tools", "Skills")
+
+REQUIRED_SKILL_FILES = (
+    "__init__.py",
+    "skill_base.py",
+    "server.py",
+    "skills/__init__.py",
+    "skills/system_skill.py",
+    "skills/config_skill.py",
+    "skills/translate_skill.py",
+    "skills/queue_skill.py",
+    "skills/profile_skill.py",
+    "skills/file_skill.py",
+)
+
+
+def _module_exists(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def inspect_skills_runtime(project_root: str | None = None) -> Dict[str, Any]:
+    """Check if the Skills framework is ready to run."""
+    resolved_root = os.path.abspath(project_root or PROJECT_ROOT)
+    component_root = os.path.join(resolved_root, "Tools", "Skills")
+
+    missing_files = [
+        os.path.join(component_root, filename)
+        for filename in REQUIRED_SKILL_FILES
+        if not os.path.exists(os.path.join(component_root, filename))
+    ]
+
+    # Skills framework has zero extra dependencies — everything is stdlib.
+    required_modules = {"json", "http.server", "urllib.parse"}
+    missing_modules = [
+        name for name in required_modules if not _module_exists(name)
+    ]
+
+    available = not missing_files and not missing_modules
+
+    return {
+        "available": available,
+        "project_root": resolved_root,
+        "component_root": component_root,
+        "missing_files": missing_files,
+        "missing_modules": missing_modules,
+        "note": "The Skills framework has no Python package dependencies beyond the standard library.",
+    }
+
+
+def format_runtime_status_lines(status: Dict[str, Any]) -> List[str]:
+    """Format runtime status into human-readable lines."""
+    lines: List[str] = []
+    missing_files = status.get("missing_files", [])
+    missing_modules = status.get("missing_modules", [])
+
+    if missing_files:
+        lines.append("Missing Skills component files:")
+        lines.extend(f"  - {path}" for path in missing_files)
+
+    if missing_modules:
+        lines.append("Missing standard library modules (unexpected):")
+        lines.extend(f"  - {name}" for name in missing_modules)
+
+    if not lines:
+        lines.append("AiNiee Skills runtime is ready (no extra dependencies required).")
+
+    return lines

--- a/Tools/Skills/server.py
+++ b/Tools/Skills/server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import secrets
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from typing import Any, Dict
@@ -34,6 +35,9 @@ if PROJECT_ROOT not in sys.path:
 from Tools.Skills.skills import build_registry
 
 
+SKILLS_AUTH_HEADER = "X-AiNiee-Skills-Auth"
+
+
 def _json_bytes(data: Any) -> bytes:
     return json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
 
@@ -43,16 +47,25 @@ class SkillsHTTPHandler(BaseHTTPRequestHandler):
 
     # Shared across all instances
     registry = build_registry()
+    auth_token: str = ""
+    require_auth: bool = True
+    allow_origin: str = ""
 
     def log_message(self, format: str, *args: Any) -> None:
         """Log to stderr so stdout stays clean for potential JSONL consumers."""
         sys.stderr.write(f"[Skills] {args[0]} {args[1]} {args[2]}\n")
 
+    def _send_cors_headers(self) -> None:
+        if not self.allow_origin:
+            return
+        self.send_header("Access-Control-Allow-Origin", self.allow_origin)
+        self.send_header("Vary", "Origin")
+
     def _send_json(self, data: Any, status: int = 200) -> None:
         body = _json_bytes(data)
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self._send_cors_headers()
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -73,10 +86,20 @@ class SkillsHTTPHandler(BaseHTTPRequestHandler):
     def do_OPTIONS(self) -> None:
         """Handle CORS preflight."""
         self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self._send_cors_headers()
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header(
+            "Access-Control-Allow-Headers",
+            f"Content-Type, {SKILLS_AUTH_HEADER}",
+        )
         self.end_headers()
+
+    def _is_authorized(self) -> bool:
+        if not self.require_auth:
+            return True
+        token = self.auth_token
+        provided = self.headers.get(SKILLS_AUTH_HEADER, "")
+        return bool(token) and secrets.compare_digest(str(provided), token)
 
     def do_GET(self) -> None:
         parsed = urlparse(self.path)
@@ -113,6 +136,9 @@ class SkillsHTTPHandler(BaseHTTPRequestHandler):
         path = parsed.path.rstrip("/")
 
         if path.startswith("/skills/"):
+            if not self._is_authorized():
+                self._send_error(401, "Missing or invalid Skills auth token.", "UNAUTHORIZED")
+                return
             name = path[len("/skills/"):]
             body = self._read_body()
             args = body.get("args", body)
@@ -129,8 +155,18 @@ class SkillsHTTPHandler(BaseHTTPRequestHandler):
 def run_server(
     host: str = "127.0.0.1",
     port: int = 8766,
+    *,
+    auth_token: str | None = None,
+    require_auth: bool = True,
+    allow_origin: str = "",
 ) -> None:
     """Start the Skills HTTP server."""
+    if require_auth and not auth_token:
+        auth_token = os.environ.get("AINIEE_SKILLS_AUTH_TOKEN") or secrets.token_urlsafe(24)
+    SkillsHTTPHandler.auth_token = auth_token or ""
+    SkillsHTTPHandler.require_auth = require_auth
+    SkillsHTTPHandler.allow_origin = allow_origin or ""
+
     server = HTTPServer((host, port), SkillsHTTPHandler)
     sys.stderr.write(
         f"[Skills] Server starting on http://{host}:{port}\n"
@@ -140,6 +176,12 @@ def run_server(
         f"[Skills]   GET  /skills/<name> — Describe a skill\n"
         f"[Skills]   POST /skills/<name> — Execute a skill\n"
     )
+    if require_auth:
+        sys.stderr.write(
+            f"[Skills] POST auth header: {SKILLS_AUTH_HEADER}: {SkillsHTTPHandler.auth_token}\n"
+        )
+    else:
+        sys.stderr.write("[Skills] WARNING: HTTP auth is disabled.\n")
     try:
         server.serve_forever()
     except KeyboardInterrupt:
@@ -150,13 +192,24 @@ def run_server(
 def run_server_detached(
     host: str = "127.0.0.1",
     port: int = 8766,
+    *,
+    auth_token: str | None = None,
+    require_auth: bool = True,
+    allow_origin: str = "",
 ) -> HTTPServer:
     """Start server in a way that can be stopped programmatically."""
+    if require_auth and not auth_token:
+        auth_token = os.environ.get("AINIEE_SKILLS_AUTH_TOKEN") or secrets.token_urlsafe(24)
+    SkillsHTTPHandler.auth_token = auth_token or ""
+    SkillsHTTPHandler.require_auth = require_auth
+    SkillsHTTPHandler.allow_origin = allow_origin or ""
+
     server = HTTPServer((host, port), SkillsHTTPHandler)
     import threading
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    sys.stderr.write(f"[Skills] Server started (detached) on http://{host}:{port}\n")
+    actual_host, actual_port = server.server_address
+    sys.stderr.write(f"[Skills] Server started (detached) on http://{actual_host}:{actual_port}\n")
     return server
 
 
@@ -164,6 +217,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="AiNiee Skills HTTP Server")
     parser.add_argument("--host", default="127.0.0.1", help="Host address.")
     parser.add_argument("--port", type=int, default=8766, help="Port number.")
+    parser.add_argument("--auth-token", default=None, help="HTTP auth token.")
+    parser.add_argument(
+        "--no-auth",
+        action="store_true",
+        help="Disable HTTP auth. Only use on trusted local machines.",
+    )
+    parser.add_argument(
+        "--allow-origin",
+        default="",
+        help="Optional CORS Access-Control-Allow-Origin value.",
+    )
     return parser
 
 
@@ -171,7 +235,13 @@ def main() -> int:
     parser = build_arg_parser()
     args = parser.parse_args()
     try:
-        run_server(host=args.host, port=args.port)
+        run_server(
+            host=args.host,
+            port=args.port,
+            auth_token=args.auth_token,
+            require_auth=not args.no_auth,
+            allow_origin=args.allow_origin,
+        )
     except KeyboardInterrupt:
         pass
     return 0

--- a/Tools/Skills/server.py
+++ b/Tools/Skills/server.py
@@ -1,0 +1,181 @@
+"""
+AiNiee Skills HTTP Server
+
+A lightweight REST server that exposes the Skills framework over HTTP.
+No MCP, no FastAPI, no uvicorn — just the Python standard library.
+
+Endpoints:
+    GET  /skills              — List all skills with metadata
+    GET  /skills/<name>       — Describe a specific skill
+    POST /skills/<name>       — Execute a skill with arguments
+    GET  /health              — Health check
+
+Usage:
+    python Tools/Skills/server.py [--port PORT] [--host HOST]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from Tools.Skills.skills import build_registry
+
+
+def _json_bytes(data: Any) -> bytes:
+    return json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+
+
+class SkillsHTTPHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the Skills server."""
+
+    # Shared across all instances
+    registry = build_registry()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Log to stderr so stdout stays clean for potential JSONL consumers."""
+        sys.stderr.write(f"[Skills] {args[0]} {args[1]} {args[2]}\n")
+
+    def _send_json(self, data: Any, status: int = 200) -> None:
+        body = _json_bytes(data)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_error(self, status: int, message: str, code: str = "") -> None:
+        self._send_json({"error": message, "error_code": code}, status)
+
+    def _read_body(self) -> Dict[str, Any]:
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length == 0:
+            return {}
+        raw = self.rfile.read(content_length)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+
+    def do_OPTIONS(self) -> None:
+        """Handle CORS preflight."""
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        if path == "/health":
+            self._send_json({
+                "status": "ok",
+                "service": "ainiee-skills",
+                "skills_count": self.registry.count,
+            })
+            return
+
+        if path == "/skills":
+            self._send_json({
+                "skills": self.registry.list_skills(),
+                "count": self.registry.count,
+            })
+            return
+
+        if path.startswith("/skills/"):
+            name = path[len("/skills/"):]
+            try:
+                meta = self.registry.get_skill_meta(name)
+                self._send_json(meta)
+            except Exception as e:
+                self._send_error(404, str(e), "UNKNOWN_SKILL")
+            return
+
+        self._send_error(404, f"Not found: {path}", "NOT_FOUND")
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        if path.startswith("/skills/"):
+            name = path[len("/skills/"):]
+            body = self._read_body()
+            args = body.get("args", body)
+            try:
+                result = self.registry.execute(name, args)
+                self._send_json(result.to_dict())
+            except Exception as e:
+                self._send_error(500, str(e), "EXECUTION_ERROR")
+            return
+
+        self._send_error(404, f"Not found: {path}", "NOT_FOUND")
+
+
+def run_server(
+    host: str = "127.0.0.1",
+    port: int = 8766,
+) -> None:
+    """Start the Skills HTTP server."""
+    server = HTTPServer((host, port), SkillsHTTPHandler)
+    sys.stderr.write(
+        f"[Skills] Server starting on http://{host}:{port}\n"
+        f"[Skills] Endpoints:\n"
+        f"[Skills]   GET  /health       — Health check\n"
+        f"[Skills]   GET  /skills       — List all skills\n"
+        f"[Skills]   GET  /skills/<name> — Describe a skill\n"
+        f"[Skills]   POST /skills/<name> — Execute a skill\n"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("[Skills] Shutting down...\n")
+        server.server_close()
+
+
+def run_server_detached(
+    host: str = "127.0.0.1",
+    port: int = 8766,
+) -> HTTPServer:
+    """Start server in a way that can be stopped programmatically."""
+    server = HTTPServer((host, port), SkillsHTTPHandler)
+    import threading
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    sys.stderr.write(f"[Skills] Server started (detached) on http://{host}:{port}\n")
+    return server
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="AiNiee Skills HTTP Server")
+    parser.add_argument("--host", default="127.0.0.1", help="Host address.")
+    parser.add_argument("--port", type=int, default=8766, help="Port number.")
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    try:
+        run_server(host=args.host, port=args.port)
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/Skills/skill_base.py
+++ b/Tools/Skills/skill_base.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import abc
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+
+class SkillError(Exception):
+    """Raised when a skill execution fails for a known reason."""
+
+    def __init__(self, message: str, code: str = "SKILL_ERROR") -> None:
+        self.code = code
+        super().__init__(message)
+
+
+class SkillResult:
+    """Wrapper for skill execution results."""
+
+    def __init__(
+        self,
+        success: bool,
+        data: Any = None,
+        error: Optional[str] = None,
+        error_code: str = "",
+    ) -> None:
+        self.success = success
+        self.data = data
+        self.error = error
+        self.error_code = error_code
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"success": self.success}
+        if self.data is not None:
+            d["data"] = self.data
+        if self.error:
+            d["error"] = self.error
+            d["error_code"] = self.error_code
+        return d
+
+    @classmethod
+    def ok(cls, data: Any = None) -> SkillResult:
+        return cls(success=True, data=data)
+
+    @classmethod
+    def fail(cls, message: str, code: str = "SKILL_ERROR") -> SkillResult:
+        return cls(success=False, error=message, error_code=code)
+
+
+@dataclass
+class SkillParameter:
+    """Describes a single input parameter for a skill."""
+
+    name: str
+    description: str = ""
+    type: str = "string"  # string / integer / boolean / object / array
+    required: bool = False
+    default: Any = None
+    enum: Optional[List[str]] = None
+
+
+@dataclass
+class SkillMeta:
+    """Metadata describing a skill."""
+
+    name: str
+    description: str
+    category: str = "general"
+    parameters: List[SkillParameter] = field(default_factory=list)
+    examples: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "parameters": [
+                {
+                    "name": p.name,
+                    "description": p.description,
+                    "type": p.type,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": p.enum,
+                }
+                for p in self.parameters
+            ],
+            "examples": self.examples,
+        }
+
+
+class Skill(abc.ABC):
+    """Base class for all skills."""
+
+    def __init__(self) -> None:
+        self._meta: Optional[SkillMeta] = None
+
+    @property
+    @abc.abstractmethod
+    def meta(self) -> SkillMeta:
+        ...
+
+    @abc.abstractmethod
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        ...
+
+
+class SkillRegistry:
+    """Registry of all available skills."""
+
+    def __init__(self) -> None:
+        self._skills: Dict[str, Skill] = {}
+
+    def register(self, skill: Skill) -> None:
+        name = skill.meta.name
+        if name in self._skills:
+            raise SkillError(f"Duplicate skill registration: {name}", "DUPLICATE_SKILL")
+        self._skills[name] = skill
+
+    def get(self, name: str) -> Skill:
+        skill = self._skills.get(name)
+        if skill is None:
+            raise SkillError(f"Unknown skill: {name}", "UNKNOWN_SKILL")
+        return skill
+
+    def list_skills(self) -> List[Dict[str, Any]]:
+        return [s.meta.to_dict() for s in self._skills.values()]
+
+    def get_skill_meta(self, name: str) -> Dict[str, Any]:
+        return self.get(name).meta.to_dict()
+
+    def execute(self, name: str, args: Dict[str, Any]) -> SkillResult:
+        skill = self.get(name)
+        return skill.execute(args)
+
+    @property
+    def count(self) -> int:
+        return len(self._skills)

--- a/Tools/Skills/skill_base.py
+++ b/Tools/Skills/skill_base.py
@@ -43,8 +43,13 @@ class SkillResult:
         return cls(success=True, data=data)
 
     @classmethod
-    def fail(cls, message: str, code: str = "SKILL_ERROR") -> SkillResult:
-        return cls(success=False, error=message, error_code=code)
+    def fail(
+        cls,
+        message: str,
+        code: str = "SKILL_ERROR",
+        data: Any = None,
+    ) -> SkillResult:
+        return cls(success=False, data=data, error=message, error_code=code)
 
 
 @dataclass

--- a/Tools/Skills/skills/__init__.py
+++ b/Tools/Skills/skills/__init__.py
@@ -1,0 +1,21 @@
+"""Skill implementations for AiNiee Skills."""
+
+from Tools.Skills.skill_base import SkillRegistry
+from Tools.Skills.skills.system_skill import SystemSkill
+from Tools.Skills.skills.config_skill import ConfigSkill
+from Tools.Skills.skills.translate_skill import TranslateSkill
+from Tools.Skills.skills.queue_skill import QueueSkill
+from Tools.Skills.skills.profile_skill import ProfileSkill
+from Tools.Skills.skills.file_skill import FileSkill
+
+
+def build_registry() -> SkillRegistry:
+    """Create and populate the global skill registry."""
+    registry = SkillRegistry()
+    registry.register(SystemSkill())
+    registry.register(ConfigSkill())
+    registry.register(TranslateSkill())
+    registry.register(QueueSkill())
+    registry.register(ProfileSkill())
+    registry.register(FileSkill())
+    return registry

--- a/Tools/Skills/skills/common.py
+++ b/Tools/Skills/skills/common.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Tuple
+
+from ModuleFolders.Infrastructure.TaskConfig.ConfigProfileService import (
+    PROFILES_PATH,
+    atomic_write_json,
+    get_active_profile_name,
+    list_profile_names,
+    load_json_file,
+    load_root_config,
+    resolve_profile_path,
+    save_root_config,
+)
+from Tools.MCPServer.security import (
+    contains_redacted_secret,
+    restore_redacted_secrets,
+    sanitize_data_for_mcp,
+    strip_mcp_security_metadata,
+)
+
+
+CONFIG_SECURITY_PATH = "/api/config"
+QUEUE_SECURITY_PATH = "/api/queue/raw"
+
+
+def load_dict_json(path: str) -> Dict[str, Any]:
+    """Load a JSON object from disk and return an empty dict on invalid data."""
+    try:
+        data = load_json_file(path, {})
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def active_profile_name() -> str:
+    return get_active_profile_name(load_root_config())
+
+
+def resolve_config_profile_path(profile: Any = None) -> Tuple[str, str]:
+    """Resolve a profile file path without allowing path traversal."""
+    profile_name = profile or active_profile_name()
+    return resolve_profile_path(PROFILES_PATH, profile_name)
+
+
+def sanitize_config_value(value: Any, key: str) -> Any:
+    """Redact a config value when exposing it to Skills clients."""
+    return sanitize_data_for_mcp(
+        value,
+        path=CONFIG_SECURITY_PATH,
+        field_name=key,
+    )
+
+
+def sanitize_payload(data: Any, *, path: str = CONFIG_SECURITY_PATH) -> Any:
+    return sanitize_data_for_mcp(data, path=path)
+
+
+def prepare_config_value_for_save(value: Any, current_value: Any, key: str) -> Any:
+    """
+    Restore redacted secret placeholders before saving.
+
+    This lets a client round-trip sanitized data without overwriting an existing
+    API key with "[MCP_SECRET_REDACTED]".
+    """
+    clean_value = strip_mcp_security_metadata(copy.deepcopy(value))
+    restored = restore_redacted_secrets(clean_value, current_value, field_name=key)
+    if contains_redacted_secret(restored, field_name=key):
+        raise ValueError(
+            f"Refusing to save redacted placeholder for sensitive config key: {key}"
+        )
+    return restored

--- a/Tools/Skills/skills/config_skill.py
+++ b/Tools/Skills/skills/config_skill.py
@@ -1,35 +1,20 @@
 from __future__ import annotations
 
-import json
-import os
 from typing import Any, Dict
 
 from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
-
-
-PROJECT_ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+from Tools.Skills.skills.common import (
+    active_profile_name,
+    atomic_write_json,
+    load_dict_json,
+    load_root_config,
+    prepare_config_value_for_save,
+    resolve_config_profile_path,
+    sanitize_config_value,
 )
-RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "Resource")
-PROFILES_PATH = os.path.join(RESOURCE_ROOT, "profiles")
-ROOT_CONFIG = os.path.join(RESOURCE_ROOT, "config.json")
 
 
-def _safe_load_json(path: str) -> Dict[str, Any]:
-    try:
-        with open(path, "r", encoding="utf-8-sig") as f:
-            return json.load(f) if isinstance((d := json.load(f)), dict) else {}
-    except Exception:
-        return {}
-
-
-def _active_profile_name() -> str:
-    root = _safe_load_json(ROOT_CONFIG)
-    return str(root.get("active_profile", "default") or "default")
-
-
-def _active_profile_path() -> str:
-    return os.path.join(PROFILES_PATH, f"{_active_profile_name()}.json")
+_MISSING = object()
 
 
 class ConfigSkill(Skill):
@@ -78,31 +63,41 @@ class ConfigSkill(Skill):
         action = (args.get("action") or "").strip().lower()
 
         if action == "list_keys":
-            profile = args.get("profile") or _active_profile_name()
-            path = os.path.join(PROFILES_PATH, f"{profile}.json")
-            cfg = _safe_load_json(path)
+            try:
+                path, profile = resolve_config_profile_path(args.get("profile"))
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
+            cfg = load_dict_json(path)
             return SkillResult.ok({
                 "profile": profile,
-                "keys": list(cfg.keys()),
+                "keys": sorted(cfg.keys()),
             })
 
         if action == "get":
             key = (args.get("key") or "").strip()
             if not key:
                 return SkillResult.fail("Missing required parameter: key", "MISSING_PARAM")
-            profile = args.get("profile") or _active_profile_name()
-            path = os.path.join(PROFILES_PATH, f"{profile}.json")
-            cfg = _safe_load_json(path)
-            value = cfg.get(key)
-            if value is None:
-                # Also try root config
-                root = _safe_load_json(ROOT_CONFIG)
-                value = root.get(key)
+            try:
+                path, profile = resolve_config_profile_path(args.get("profile"))
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
+
+            cfg = load_dict_json(path)
+            value = cfg.get(key, _MISSING)
+            source = "profile"
+            if value is _MISSING:
+                root = load_root_config()
+                value = root.get(key, _MISSING)
+                source = "root"
+
+            found = value is not _MISSING
+            exposed_value = None if not found else sanitize_config_value(value, key)
             return SkillResult.ok({
                 "profile": profile,
                 "key": key,
-                "value": value,
-                "found": value is not None,
+                "value": exposed_value,
+                "found": found,
+                "source": source if found else None,
             })
 
         if action == "set":
@@ -111,17 +106,27 @@ class ConfigSkill(Skill):
                 return SkillResult.fail("Missing required parameter: key", "MISSING_PARAM")
             if "value" not in args:
                 return SkillResult.fail("Missing required parameter: value", "MISSING_PARAM")
-            value = args["value"]
-            profile = args.get("profile") or _active_profile_name()
+            try:
+                path, profile = resolve_config_profile_path(args.get("profile") or active_profile_name())
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
 
-            path = os.path.join(PROFILES_PATH, f"{profile}.json")
-            cfg = _safe_load_json(path)
+            cfg = load_dict_json(path)
+            try:
+                value = prepare_config_value_for_save(args["value"], cfg.get(key), key)
+            except ValueError as e:
+                return SkillResult.fail(str(e), "REDACTED_SECRET")
+
             cfg[key] = value
             try:
-                with open(path, "w", encoding="utf-8") as f:
-                    json.dump(cfg, f, ensure_ascii=False, indent=2)
-                return SkillResult.ok({"profile": profile, "key": key, "value": value, "saved": True})
-            except OSError as e:
+                atomic_write_json(path, cfg)
+                return SkillResult.ok({
+                    "profile": profile,
+                    "key": key,
+                    "value": sanitize_config_value(value, key),
+                    "saved": True,
+                })
+            except Exception as e:
                 return SkillResult.fail(f"Failed to write config: {e}", "WRITE_ERROR")
 
         return SkillResult.fail(f"Unknown config action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/config_skill.py
+++ b/Tools/Skills/skills/config_skill.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "Resource")
+PROFILES_PATH = os.path.join(RESOURCE_ROOT, "profiles")
+ROOT_CONFIG = os.path.join(RESOURCE_ROOT, "config.json")
+
+
+def _safe_load_json(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            return json.load(f) if isinstance((d := json.load(f)), dict) else {}
+    except Exception:
+        return {}
+
+
+def _active_profile_name() -> str:
+    root = _safe_load_json(ROOT_CONFIG)
+    return str(root.get("active_profile", "default") or "default")
+
+
+def _active_profile_path() -> str:
+    return os.path.join(PROFILES_PATH, f"{_active_profile_name()}.json")
+
+
+class ConfigSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="config",
+            description="Read and write AiNiee profile configuration.",
+            category="config",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: get, set, list_keys.",
+                    type="string",
+                    required=True,
+                    enum=["get", "set", "list_keys"],
+                ),
+                SkillParameter(
+                    name="key",
+                    description="Configuration key to read or write.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="value",
+                    description="Value to set (for set action).",
+                    type="object",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="profile",
+                    description="Profile name (defaults to active profile).",
+                    type="string",
+                    required=False,
+                ),
+            ],
+            examples=[
+                {"action": "get", "key": "model"},
+                {"action": "get", "key": "target_platform"},
+                {"action": "list_keys"},
+                {"action": "set", "key": "model", "value": "gpt-4o-mini"},
+            ],
+        )
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list_keys":
+            profile = args.get("profile") or _active_profile_name()
+            path = os.path.join(PROFILES_PATH, f"{profile}.json")
+            cfg = _safe_load_json(path)
+            return SkillResult.ok({
+                "profile": profile,
+                "keys": list(cfg.keys()),
+            })
+
+        if action == "get":
+            key = (args.get("key") or "").strip()
+            if not key:
+                return SkillResult.fail("Missing required parameter: key", "MISSING_PARAM")
+            profile = args.get("profile") or _active_profile_name()
+            path = os.path.join(PROFILES_PATH, f"{profile}.json")
+            cfg = _safe_load_json(path)
+            value = cfg.get(key)
+            if value is None:
+                # Also try root config
+                root = _safe_load_json(ROOT_CONFIG)
+                value = root.get(key)
+            return SkillResult.ok({
+                "profile": profile,
+                "key": key,
+                "value": value,
+                "found": value is not None,
+            })
+
+        if action == "set":
+            key = (args.get("key") or "").strip()
+            if not key:
+                return SkillResult.fail("Missing required parameter: key", "MISSING_PARAM")
+            if "value" not in args:
+                return SkillResult.fail("Missing required parameter: value", "MISSING_PARAM")
+            value = args["value"]
+            profile = args.get("profile") or _active_profile_name()
+
+            path = os.path.join(PROFILES_PATH, f"{profile}.json")
+            cfg = _safe_load_json(path)
+            cfg[key] = value
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(cfg, f, ensure_ascii=False, indent=2)
+                return SkillResult.ok({"profile": profile, "key": key, "value": value, "saved": True})
+            except OSError as e:
+                return SkillResult.fail(f"Failed to write config: {e}", "WRITE_ERROR")
+
+        return SkillResult.fail(f"Unknown config action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/file_skill.py
+++ b/Tools/Skills/skills/file_skill.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+
+class FileSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="file",
+            description="File discovery and staging for translation tasks.",
+            category="files",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: list, info, upload_path.",
+                    type="string",
+                    required=True,
+                    enum=["list", "info", "upload_path"],
+                ),
+                SkillParameter(
+                    name="path",
+                    description="Directory path (for list) or file path (for info).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="pattern",
+                    description="Glob pattern for file filtering (e.g., '*.txt', '*.epub').",
+                    type="string",
+                    required=False,
+                    default="*",
+                ),
+            ],
+            examples=[
+                {"action": "list", "path": "/path/to/input", "pattern": "*.txt"},
+                {"action": "info", "path": "/path/to/file.txt"},
+                {"action": "upload_path", "path": "/path/to/file.txt"},
+            ],
+        )
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list":
+            import glob as glob_module
+
+            path = args.get("path") or "."
+            pattern = args.get("pattern") or "*"
+            search = os.path.join(path, pattern) if os.path.isdir(path) else path
+            files = sorted(glob_module.glob(search))
+            result = []
+            for f in files:
+                stat = os.stat(f)
+                result.append({
+                    "name": os.path.basename(f),
+                    "path": os.path.abspath(f),
+                    "size": stat.st_size,
+                    "is_dir": os.path.isdir(f),
+                    "ext": os.path.splitext(f)[1].lower(),
+                })
+            return SkillResult.ok({
+                "count": len(result),
+                "files": result,
+                "search_path": search,
+            })
+
+        if action == "info":
+            path = args.get("path", "")
+            if not path:
+                return SkillResult.fail("Missing required parameter: path", "MISSING_PARAM")
+            if not os.path.exists(path):
+                return SkillResult.fail(f"Path not found: {path}", "NOT_FOUND")
+            stat = os.stat(path)
+            supported_exts = {
+                ".txt", ".epub", ".docx", ".srt", ".ass", ".vtt", ".lrc",
+                ".json", ".po", ".xlsx", ".csv", ".mobi", ".azw3", ".fb2",
+                ".pdf", ".png", ".jpg", ".jpeg", ".webp", ".cbz", ".cbr",
+                ".html", ".htm", ".md", ".xml", ".yaml", ".yml", ".ts", ".srt",
+            }
+            ext = os.path.splitext(path)[1].lower()
+            return SkillResult.ok({
+                "name": os.path.basename(path),
+                "path": os.path.abspath(path),
+                "size": stat.st_size,
+                "is_dir": os.path.isdir(path),
+                "ext": ext,
+                "supported": ext in supported_exts,
+            })
+
+        if action == "upload_path":
+            """Return the project staging path suggestion for a file."""
+            path = args.get("path", "")
+            if not path:
+                return SkillResult.fail("Missing required parameter: path", "MISSING_PARAM")
+            if not os.path.exists(path):
+                return SkillResult.fail(f"Path not found: {path}", "NOT_FOUND")
+
+            return SkillResult.ok({
+                "local_path": os.path.abspath(path),
+                "note": "Use this path as input_path for translate skill or queue skill.",
+            })
+
+        return SkillResult.fail(f"Unknown file action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/profile_skill.py
+++ b/Tools/Skills/skills/profile_skill.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "Resource")
+PROFILES_PATH = os.path.join(RESOURCE_ROOT, "profiles")
+ROOT_CONFIG = os.path.join(RESOURCE_ROOT, "config.json")
+
+
+def _safe_load_json(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            return json.load(f) if isinstance((d := json.load(f)), dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_root_config(cfg: Dict[str, Any]) -> bool:
+    try:
+        with open(ROOT_CONFIG, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, ensure_ascii=False, indent=2)
+        return True
+    except OSError:
+        return False
+
+
+class ProfileSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="profile",
+            description="Manage AiNiee configuration profiles.",
+            category="config",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: list, switch, create, delete, current.",
+                    type="string",
+                    required=True,
+                    enum=["list", "switch", "create", "delete", "current"],
+                ),
+                SkillParameter(
+                    name="name",
+                    description="Profile name (for switch/create/delete).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="base",
+                    description="Base profile to copy from (for create).",
+                    type="string",
+                    required=False,
+                ),
+            ],
+            examples=[
+                {"action": "list"},
+                {"action": "current"},
+                {"action": "switch", "name": "my-profile"},
+                {"action": "create", "name": "new-profile", "base": "default"},
+                {"action": "delete", "name": "old-profile"},
+            ],
+        )
+
+    def _list_profiles(self) -> List[str]:
+        if not os.path.isdir(PROFILES_PATH):
+            return []
+        return sorted([
+            n[:-5] for n in os.listdir(PROFILES_PATH)
+            if n.endswith(".json")
+        ])
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list":
+            profiles = self._list_profiles()
+            root = _safe_load_json(ROOT_CONFIG)
+            active = root.get("active_profile", "default")
+            return SkillResult.ok({
+                "profiles": profiles,
+                "active": active,
+                "count": len(profiles),
+            })
+
+        if action == "current":
+            root = _safe_load_json(ROOT_CONFIG)
+            active = root.get("active_profile", "default")
+            rules_active = root.get("active_rules_profile", "default")
+            return SkillResult.ok({
+                "active_profile": active,
+                "active_rules_profile": rules_active,
+            })
+
+        if action == "switch":
+            name = (args.get("name") or "").strip()
+            if not name:
+                return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            profiles = self._list_profiles()
+            if name not in profiles:
+                return SkillResult.fail(
+                    f"Profile '{name}' not found. Available: {', '.join(profiles)}",
+                    "NOT_FOUND",
+                )
+            root = _safe_load_json(ROOT_CONFIG)
+            root["active_profile"] = name
+            if _save_root_config(root):
+                return SkillResult.ok({
+                    "switched": True,
+                    "profile": name,
+                    "previous": root.get("active_profile"),
+                })
+            return SkillResult.fail("Failed to save config.", "WRITE_ERROR")
+
+        if action == "create":
+            name = (args.get("name") or "").strip()
+            if not name:
+                return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            profile_path = os.path.join(PROFILES_PATH, f"{name}.json")
+            if os.path.exists(profile_path):
+                return SkillResult.fail(f"Profile '{name}' already exists.", "ALREADY_EXISTS")
+
+            base = (args.get("base") or "default").strip()
+            base_path = os.path.join(PROFILES_PATH, f"{base}.json")
+            if os.path.isfile(base_path):
+                try:
+                    with open(base_path, "r", encoding="utf-8") as f:
+                        base_data = json.load(f)
+                    with open(profile_path, "w", encoding="utf-8") as f:
+                        json.dump(base_data or {}, f, ensure_ascii=False, indent=2)
+                except (OSError, json.JSONDecodeError) as e:
+                    return SkillResult.fail(f"Failed to create profile: {e}", "CREATE_ERROR")
+            else:
+                # Create empty profile
+                try:
+                    with open(profile_path, "w", encoding="utf-8") as f:
+                        json.dump({}, f, ensure_ascii=False, indent=2)
+                except OSError as e:
+                    return SkillResult.fail(f"Failed to create profile: {e}", "CREATE_ERROR")
+
+            return SkillResult.ok({
+                "created": True,
+                "profile": name,
+                "based_on": base if os.path.isfile(base_path) else None,
+            })
+
+        if action == "delete":
+            name = (args.get("name") or "").strip()
+            if not name:
+                return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            if name == "default":
+                return SkillResult.fail("Cannot delete the default profile.", "PROTECTED")
+
+            profile_path = os.path.join(PROFILES_PATH, f"{name}.json")
+            if not os.path.isfile(profile_path):
+                return SkillResult.fail(f"Profile '{name}' not found.", "NOT_FOUND")
+
+            root = _safe_load_json(ROOT_CONFIG)
+            if root.get("active_profile") == name:
+                root["active_profile"] = "default"
+                _save_root_config(root)
+
+            try:
+                os.remove(profile_path)
+                return SkillResult.ok({"deleted": True, "profile": name})
+            except OSError as e:
+                return SkillResult.fail(f"Failed to delete profile: {e}", "DELETE_ERROR")
+
+        return SkillResult.fail(f"Unknown profile action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/profile_skill.py
+++ b/Tools/Skills/skills/profile_skill.py
@@ -1,35 +1,18 @@
 from __future__ import annotations
 
-import json
 import os
 from typing import Any, Dict, List
 
 from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
-
-
-PROJECT_ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+from Tools.Skills.skills.common import (
+    PROFILES_PATH,
+    atomic_write_json,
+    list_profile_names,
+    load_dict_json,
+    load_root_config,
+    resolve_profile_path,
+    save_root_config,
 )
-RESOURCE_ROOT = os.path.join(PROJECT_ROOT, "Resource")
-PROFILES_PATH = os.path.join(RESOURCE_ROOT, "profiles")
-ROOT_CONFIG = os.path.join(RESOURCE_ROOT, "config.json")
-
-
-def _safe_load_json(path: str) -> Dict[str, Any]:
-    try:
-        with open(path, "r", encoding="utf-8-sig") as f:
-            return json.load(f) if isinstance((d := json.load(f)), dict) else {}
-    except Exception:
-        return {}
-
-
-def _save_root_config(cfg: Dict[str, Any]) -> bool:
-    try:
-        with open(ROOT_CONFIG, "w", encoding="utf-8") as f:
-            json.dump(cfg, f, ensure_ascii=False, indent=2)
-        return True
-    except OSError:
-        return False
 
 
 class ProfileSkill(Skill):
@@ -70,19 +53,14 @@ class ProfileSkill(Skill):
         )
 
     def _list_profiles(self) -> List[str]:
-        if not os.path.isdir(PROFILES_PATH):
-            return []
-        return sorted([
-            n[:-5] for n in os.listdir(PROFILES_PATH)
-            if n.endswith(".json")
-        ])
+        return list_profile_names(PROFILES_PATH)
 
     def execute(self, args: Dict[str, Any]) -> SkillResult:
         action = (args.get("action") or "").strip().lower()
 
         if action == "list":
             profiles = self._list_profiles()
-            root = _safe_load_json(ROOT_CONFIG)
+            root = load_root_config()
             active = root.get("active_profile", "default")
             return SkillResult.ok({
                 "profiles": profiles,
@@ -91,7 +69,7 @@ class ProfileSkill(Skill):
             })
 
         if action == "current":
-            root = _safe_load_json(ROOT_CONFIG)
+            root = load_root_config()
             active = root.get("active_profile", "default")
             rules_active = root.get("active_rules_profile", "default")
             return SkillResult.ok({
@@ -103,46 +81,55 @@ class ProfileSkill(Skill):
             name = (args.get("name") or "").strip()
             if not name:
                 return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            try:
+                _, name = resolve_profile_path(PROFILES_PATH, name)
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
             profiles = self._list_profiles()
             if name not in profiles:
                 return SkillResult.fail(
                     f"Profile '{name}' not found. Available: {', '.join(profiles)}",
                     "NOT_FOUND",
                 )
-            root = _safe_load_json(ROOT_CONFIG)
+            root = load_root_config()
+            previous = root.get("active_profile", "default")
             root["active_profile"] = name
-            if _save_root_config(root):
+            try:
+                save_root_config(root)
                 return SkillResult.ok({
                     "switched": True,
                     "profile": name,
-                    "previous": root.get("active_profile"),
+                    "previous": previous,
                 })
-            return SkillResult.fail("Failed to save config.", "WRITE_ERROR")
+            except Exception as e:
+                return SkillResult.fail(f"Failed to save config: {e}", "WRITE_ERROR")
 
         if action == "create":
             name = (args.get("name") or "").strip()
             if not name:
                 return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
-            profile_path = os.path.join(PROFILES_PATH, f"{name}.json")
+            try:
+                profile_path, name = resolve_profile_path(PROFILES_PATH, name)
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
             if os.path.exists(profile_path):
                 return SkillResult.fail(f"Profile '{name}' already exists.", "ALREADY_EXISTS")
 
             base = (args.get("base") or "default").strip()
-            base_path = os.path.join(PROFILES_PATH, f"{base}.json")
+            try:
+                base_path, base = resolve_profile_path(PROFILES_PATH, base)
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
             if os.path.isfile(base_path):
                 try:
-                    with open(base_path, "r", encoding="utf-8") as f:
-                        base_data = json.load(f)
-                    with open(profile_path, "w", encoding="utf-8") as f:
-                        json.dump(base_data or {}, f, ensure_ascii=False, indent=2)
-                except (OSError, json.JSONDecodeError) as e:
+                    base_data = load_dict_json(base_path)
+                    atomic_write_json(profile_path, base_data or {})
+                except Exception as e:
                     return SkillResult.fail(f"Failed to create profile: {e}", "CREATE_ERROR")
             else:
-                # Create empty profile
                 try:
-                    with open(profile_path, "w", encoding="utf-8") as f:
-                        json.dump({}, f, ensure_ascii=False, indent=2)
-                except OSError as e:
+                    atomic_write_json(profile_path, {})
+                except Exception as e:
                     return SkillResult.fail(f"Failed to create profile: {e}", "CREATE_ERROR")
 
             return SkillResult.ok({
@@ -155,17 +142,23 @@ class ProfileSkill(Skill):
             name = (args.get("name") or "").strip()
             if not name:
                 return SkillResult.fail("Missing required parameter: name", "MISSING_PARAM")
+            try:
+                profile_path, name = resolve_profile_path(PROFILES_PATH, name)
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_PROFILE")
             if name == "default":
                 return SkillResult.fail("Cannot delete the default profile.", "PROTECTED")
 
-            profile_path = os.path.join(PROFILES_PATH, f"{name}.json")
             if not os.path.isfile(profile_path):
                 return SkillResult.fail(f"Profile '{name}' not found.", "NOT_FOUND")
 
-            root = _safe_load_json(ROOT_CONFIG)
+            root = load_root_config()
             if root.get("active_profile") == name:
                 root["active_profile"] = "default"
-                _save_root_config(root)
+                try:
+                    save_root_config(root)
+                except Exception as e:
+                    return SkillResult.fail(f"Failed to save config: {e}", "WRITE_ERROR")
 
             try:
                 os.remove(profile_path)

--- a/Tools/Skills/skills/queue_skill.py
+++ b/Tools/Skills/skills/queue_skill.py
@@ -1,36 +1,68 @@
 from __future__ import annotations
 
-import json
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
+from ModuleFolders.Infrastructure.TaskConfig.TaskType import TaskType
+from ModuleFolders.Service.TaskQueue.QueueManager import QueueManager, QueueTaskItem
 from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+from Tools.Skills.skills.common import QUEUE_SECURITY_PATH, sanitize_payload
 
 
 PROJECT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..")
 )
-QUEUE_FILE = os.path.join(PROJECT_ROOT, "queue.json")
 
 
-def _load_queue() -> List[Dict[str, Any]]:
-    if not os.path.isfile(QUEUE_FILE):
-        return []
+_TASK_TYPE_BY_NAME = {
+    "translate": TaskType.TRANSLATION,
+    "translation": TaskType.TRANSLATION,
+    "polish": TaskType.POLISH,
+    "polishing": TaskType.POLISH,
+    "all_in_one": TaskType.TRANSLATE_AND_POLISH,
+    "translate_and_polish": TaskType.TRANSLATE_AND_POLISH,
+}
+_TASK_TYPE_LABELS = {
+    TaskType.TRANSLATION: "translate",
+    TaskType.POLISH: "polish",
+    TaskType.TRANSLATE_AND_POLISH: "all_in_one",
+}
+
+
+def _queue_manager() -> QueueManager:
+    manager = QueueManager()
+    manager.load_tasks()
+    return manager
+
+
+def _parse_task_type(value: Any) -> int:
+    if isinstance(value, int):
+        if value in _TASK_TYPE_LABELS:
+            return value
+        raise ValueError(f"Unsupported task_type: {value}")
+    normalized = str(value or "translate").strip().lower()
     try:
-        with open(QUEUE_FILE, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        return data if isinstance(data, list) else []
-    except Exception:
-        return []
+        return _TASK_TYPE_BY_NAME[normalized]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported task_type: {value}") from exc
 
 
-def _save_queue(queue: List[Dict[str, Any]]) -> bool:
+def _task_type_label(value: Any) -> str:
+    return _TASK_TYPE_LABELS.get(value, str(value))
+
+
+def _task_to_public_dict(index: int, task: QueueTaskItem) -> Dict[str, Any]:
+    item = task.to_dict()
+    item["index"] = index
+    item["task_type"] = _task_type_label(item.get("task_type"))
+    return sanitize_payload(item, path=QUEUE_SECURITY_PATH)
+
+
+def _coerce_index(value: Any) -> int:
     try:
-        with open(QUEUE_FILE, "w", encoding="utf-8") as f:
-            json.dump(queue, f, ensure_ascii=False, indent=2)
-        return True
-    except OSError:
-        return False
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("index must be an integer") from exc
 
 
 class QueueSkill(Skill):
@@ -96,74 +128,113 @@ class QueueSkill(Skill):
         action = (args.get("action") or "").strip().lower()
 
         if action == "list":
-            queue = _load_queue()
+            manager = _queue_manager()
             return SkillResult.ok({
-                "count": len(queue),
+                "queue_file": manager.queue_file,
+                "count": len(manager.tasks),
                 "items": [
-                    {
-                        "index": i,
-                        "task_type": item.get("task_type", "unknown"),
-                        "input_path": item.get("input_path", ""),
-                        "output_path": item.get("output_path", ""),
-                        "profile": item.get("profile", ""),
-                    }
-                    for i, item in enumerate(queue)
+                    _task_to_public_dict(i, task)
+                    for i, task in enumerate(manager.tasks)
                 ],
             })
 
         if action == "add":
-            item: Dict[str, Any] = {}
-            if args.get("task_type"):
-                item["task_type"] = args["task_type"]
-            if args.get("input_path"):
-                item["input_path"] = args["input_path"]
-            if args.get("output_path"):
-                item["output_path"] = args["output_path"]
-            if args.get("profile"):
-                item["profile"] = args["profile"]
-
-            if not item.get("input_path"):
+            input_path = args.get("input_path")
+            if not input_path:
                 return SkillResult.fail(
                     "input_path is required for queue items.", "MISSING_PARAM"
                 )
+            try:
+                task_type = _parse_task_type(args.get("task_type"))
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_TASK_TYPE")
 
-            queue = _load_queue()
-            queue.append(item)
-            if _save_queue(queue):
-                return SkillResult.ok({
-                    "added": True,
-                    "index": len(queue) - 1,
-                    "total": len(queue),
-                })
-            return SkillResult.fail("Failed to write queue file.", "WRITE_ERROR")
+            manager = _queue_manager()
+            item = QueueTaskItem(
+                task_type=task_type,
+                input_path=input_path,
+                output_path=args.get("output_path"),
+                profile=args.get("profile"),
+                rules_profile=args.get("rules_profile"),
+                source_lang=args.get("source_lang"),
+                target_lang=args.get("target_lang"),
+                project_type=args.get("project_type"),
+                platform=args.get("platform"),
+                api_url=args.get("api_url"),
+                api_key=args.get("api_key"),
+                model=args.get("model"),
+                threads=args.get("threads"),
+                retry=args.get("retry"),
+                timeout=args.get("timeout"),
+                rounds=args.get("rounds"),
+                pre_lines=args.get("pre_lines"),
+                lines_limit=args.get("lines_limit"),
+                tokens_limit=args.get("tokens_limit"),
+                think_depth=args.get("think_depth"),
+                thinking_budget=args.get("thinking_budget"),
+            )
+            try:
+                manager.add_task(item)
+            except Exception as e:
+                return SkillResult.fail(f"Failed to write queue file: {e}", "WRITE_ERROR")
+
+            index = len(manager.tasks) - 1
+            return SkillResult.ok({
+                "added": True,
+                "queue_file": manager.queue_file,
+                "index": index,
+                "total": len(manager.tasks),
+                "item": _task_to_public_dict(index, item),
+            })
 
         if action == "remove":
-            index = args.get("index")
-            if index is None:
+            if args.get("index") is None:
                 return SkillResult.fail("index is required for remove.", "MISSING_PARAM")
-            queue = _load_queue()
-            if index < 0 or index >= len(queue):
+            try:
+                index = _coerce_index(args.get("index"))
+            except ValueError as e:
+                return SkillResult.fail(str(e), "INVALID_INDEX")
+
+            manager = _queue_manager()
+            if index < 0 or index >= len(manager.tasks):
                 return SkillResult.fail(
-                    f"Index {index} out of range (0-{len(queue) - 1}).", "INVALID_INDEX"
+                    f"Index {index} out of range (0-{len(manager.tasks) - 1}).", "INVALID_INDEX"
                 )
-            removed = queue.pop(index)
-            if _save_queue(queue):
+            if not manager.can_modify_task(index):
+                return SkillResult.fail(
+                    f"Queue item {index} is locked and cannot be removed.", "LOCKED"
+                )
+            removed = _task_to_public_dict(index, manager.tasks[index])
+            if manager.remove_task(index):
                 return SkillResult.ok({
                     "removed": True,
                     "item": removed,
-                    "total": len(queue),
+                    "total": len(manager.tasks),
                 })
             return SkillResult.fail("Failed to write queue file.", "WRITE_ERROR")
 
         if action == "clear":
-            if _save_queue([]):
-                return SkillResult.ok({"cleared": True})
-            return SkillResult.fail("Failed to clear queue.", "WRITE_ERROR")
+            manager = _queue_manager()
+            locked = [
+                index
+                for index, _task in enumerate(manager.tasks)
+                if not manager.can_modify_task(index)
+            ]
+            if locked:
+                return SkillResult.fail(
+                    f"Cannot clear queue while locked items exist: {locked}",
+                    "LOCKED",
+                )
+            try:
+                manager.clear_tasks()
+                return SkillResult.ok({"cleared": True, "queue_file": manager.queue_file})
+            except Exception as e:
+                return SkillResult.fail(f"Failed to clear queue: {e}", "WRITE_ERROR")
 
         if action == "run":
             return SkillResult.ok({
-                "note": "Queue execution is available via CLI: uv run ainiee_cli.py queue --yes",
-                "command": f"cd {PROJECT_ROOT} && uv run ainiee_cli.py queue --yes",
+                "note": "Queue execution is available via CLI.",
+                "command": f"{os.path.join(PROJECT_ROOT, 'ainiee_cli.py')} queue --yes",
             })
 
         return SkillResult.fail(f"Unknown queue action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/queue_skill.py
+++ b/Tools/Skills/skills/queue_skill.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+QUEUE_FILE = os.path.join(PROJECT_ROOT, "queue.json")
+
+
+def _load_queue() -> List[Dict[str, Any]]:
+    if not os.path.isfile(QUEUE_FILE):
+        return []
+    try:
+        with open(QUEUE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _save_queue(queue: List[Dict[str, Any]]) -> bool:
+    try:
+        with open(QUEUE_FILE, "w", encoding="utf-8") as f:
+            json.dump(queue, f, ensure_ascii=False, indent=2)
+        return True
+    except OSError:
+        return False
+
+
+class QueueSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="queue",
+            description="Manage the translation task queue.",
+            category="queue",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: list, add, remove, clear, run.",
+                    type="string",
+                    required=True,
+                    enum=["list", "add", "remove", "clear", "run"],
+                ),
+                SkillParameter(
+                    name="task_type",
+                    description="Task type for new queue items (translate/polish/all_in_one).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="input_path",
+                    description="Input file path for new queue item.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="output_path",
+                    description="Output path for new queue item.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="profile",
+                    description="Profile name for queue item.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="index",
+                    description="Index of the queue item to remove.",
+                    type="integer",
+                    required=False,
+                ),
+            ],
+            examples=[
+                {"action": "list"},
+                {
+                    "action": "add",
+                    "input_path": "/path/to/file.txt",
+                    "task_type": "translate",
+                    "profile": "default",
+                },
+                {"action": "remove", "index": 0},
+                {"action": "clear"},
+            ],
+        )
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "list":
+            queue = _load_queue()
+            return SkillResult.ok({
+                "count": len(queue),
+                "items": [
+                    {
+                        "index": i,
+                        "task_type": item.get("task_type", "unknown"),
+                        "input_path": item.get("input_path", ""),
+                        "output_path": item.get("output_path", ""),
+                        "profile": item.get("profile", ""),
+                    }
+                    for i, item in enumerate(queue)
+                ],
+            })
+
+        if action == "add":
+            item: Dict[str, Any] = {}
+            if args.get("task_type"):
+                item["task_type"] = args["task_type"]
+            if args.get("input_path"):
+                item["input_path"] = args["input_path"]
+            if args.get("output_path"):
+                item["output_path"] = args["output_path"]
+            if args.get("profile"):
+                item["profile"] = args["profile"]
+
+            if not item.get("input_path"):
+                return SkillResult.fail(
+                    "input_path is required for queue items.", "MISSING_PARAM"
+                )
+
+            queue = _load_queue()
+            queue.append(item)
+            if _save_queue(queue):
+                return SkillResult.ok({
+                    "added": True,
+                    "index": len(queue) - 1,
+                    "total": len(queue),
+                })
+            return SkillResult.fail("Failed to write queue file.", "WRITE_ERROR")
+
+        if action == "remove":
+            index = args.get("index")
+            if index is None:
+                return SkillResult.fail("index is required for remove.", "MISSING_PARAM")
+            queue = _load_queue()
+            if index < 0 or index >= len(queue):
+                return SkillResult.fail(
+                    f"Index {index} out of range (0-{len(queue) - 1}).", "INVALID_INDEX"
+                )
+            removed = queue.pop(index)
+            if _save_queue(queue):
+                return SkillResult.ok({
+                    "removed": True,
+                    "item": removed,
+                    "total": len(queue),
+                })
+            return SkillResult.fail("Failed to write queue file.", "WRITE_ERROR")
+
+        if action == "clear":
+            if _save_queue([]):
+                return SkillResult.ok({"cleared": True})
+            return SkillResult.fail("Failed to clear queue.", "WRITE_ERROR")
+
+        if action == "run":
+            return SkillResult.ok({
+                "note": "Queue execution is available via CLI: uv run ainiee_cli.py queue --yes",
+                "command": f"cd {PROJECT_ROOT} && uv run ainiee_cli.py queue --yes",
+            })
+
+        return SkillResult.fail(f"Unknown queue action: {action}", "INVALID_ACTION")

--- a/Tools/Skills/skills/system_skill.py
+++ b/Tools/Skills/skills/system_skill.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+
+class SystemSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="system",
+            description="System information and health checks for the AiNiee runtime.",
+            category="system",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="The system action to perform: info, health, version, or ping.",
+                    type="string",
+                    required=True,
+                    enum=["info", "health", "version", "ping"],
+                ),
+            ],
+            examples=[
+                {"action": "info"},
+                {"action": "health"},
+                {"action": "version"},
+                {"action": "ping"},
+            ],
+        )
+
+    def _load_project_meta(self) -> Dict[str, Any]:
+        """Read version/name from pyproject.toml without pulling in a TOML lib at runtime."""
+        meta: Dict[str, Any] = {"name": "ainiee-cli", "version": "0.1.0"}
+        pyproject = os.path.join(PROJECT_ROOT, "pyproject.toml")
+        if not os.path.isfile(pyproject):
+            return meta
+        try:
+            import tomllib
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ImportError:
+                return meta
+        try:
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            project = data.get("project", {})
+            meta["name"] = project.get("name", meta["name"])
+            meta["version"] = project.get("version", meta["version"])
+        except Exception:
+            pass
+        return meta
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "info").strip().lower()
+
+        if action == "ping":
+            return SkillResult.ok({"pong": True})
+
+        if action == "version":
+            meta = self._load_project_meta()
+            return SkillResult.ok({"version": meta["version"], "name": meta["name"]})
+
+        if action == "health":
+            meta = self._load_project_meta()
+            resource_root = os.path.join(PROJECT_ROOT, "Resource")
+            config_ok = os.path.isfile(os.path.join(resource_root, "config.json"))
+            return SkillResult.ok({
+                "status": "ok" if config_ok else "degraded",
+                "version": meta["version"],
+                "python": sys.version.split()[0],
+                "platform": sys.platform,
+                "config_found": config_ok,
+                "project_root": PROJECT_ROOT,
+            })
+
+        if action == "info":
+            meta = self._load_project_meta()
+            resource_root = os.path.join(PROJECT_ROOT, "Resource")
+            profiles_dir = os.path.join(resource_root, "profiles")
+            profile_count = 0
+            if os.path.isdir(profiles_dir):
+                profile_count = len([
+                    n for n in os.listdir(profiles_dir)
+                    if n.endswith(".json")
+                ])
+            return SkillResult.ok({
+                "name": meta["name"],
+                "version": meta["version"],
+                "platform": sys.platform,
+                "python": sys.version.split()[0],
+                "profile_count": profile_count,
+                "project_root": PROJECT_ROOT,
+            })
+
+        return SkillResult.fail(
+            f"Unknown system action: {action}",
+            code="INVALID_ACTION",
+        )

--- a/Tools/Skills/skills/translate_skill.py
+++ b/Tools/Skills/skills/translate_skill.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import json
 import os
+import shlex
 import subprocess
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
 
@@ -154,12 +154,19 @@ class TranslateSkill(Skill):
 
         try:
             result = _run_ainiee_cli(cli_args, timeout=3600)
-            return SkillResult.ok({
+            data = {
                 "exit_code": result.returncode,
                 "stdout": result.stdout[-2000:] if result.stdout else "",
                 "stderr": result.stderr[-2000:] if result.stderr else "",
-                "command": "uv run ainiee_cli.py " + " ".join(cli_args),
-            })
+                "command": shlex.join([sys.executable, "-m", "ainiee_cli", *cli_args]),
+            }
+            if result.returncode != 0:
+                return SkillResult.fail(
+                    f"Translation subprocess failed with exit code {result.returncode}.",
+                    "SUBPROCESS_FAILED",
+                    data=data,
+                )
+            return SkillResult.ok(data)
         except subprocess.TimeoutExpired:
             return SkillResult.fail("Translation task timed out.", "TIMEOUT")
         except FileNotFoundError as e:

--- a/Tools/Skills/skills/translate_skill.py
+++ b/Tools/Skills/skills/translate_skill.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional
+
+from Tools.Skills.skill_base import Skill, SkillMeta, SkillParameter, SkillResult
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+
+
+def _run_ainiee_cli(args: List[str], timeout: int = 300) -> subprocess.CompletedProcess:
+    """Run a CLI subcommand and return the result."""
+    cmd = [sys.executable, "-m", "ainiee_cli"] + args
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=PROJECT_ROOT,
+    )
+
+
+class TranslateSkill(Skill):
+    @property
+    def meta(self) -> SkillMeta:
+        return SkillMeta(
+            name="translate",
+            description="Execute translation, polishing, and all-in-one tasks.",
+            category="task",
+            parameters=[
+                SkillParameter(
+                    name="action",
+                    description="Operation: run, status.",
+                    type="string",
+                    required=True,
+                    enum=["run", "status"],
+                ),
+                SkillParameter(
+                    name="task_type",
+                    description="Type of task: translate, polish, or all_in_one.",
+                    type="string",
+                    required=False,
+                    default="translate",
+                    enum=["translate", "polish", "all_in_one"],
+                ),
+                SkillParameter(
+                    name="input_path",
+                    description="Path to the input file or directory.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="output_path",
+                    description="Output directory path.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="profile",
+                    description="Configuration profile name.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="source_lang",
+                    description="Source language.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="target_lang",
+                    description="Target language.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="project_type",
+                    description="Project type (Txt, Epub, MTool, RenPy, etc.).",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="threads",
+                    description="Concurrent thread count.",
+                    type="integer",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="model",
+                    description="Model name override.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="platform",
+                    description="API platform override.",
+                    type="string",
+                    required=False,
+                ),
+                SkillParameter(
+                    name="resume",
+                    description="Resume from cache if available.",
+                    type="boolean",
+                    required=False,
+                    default=False,
+                ),
+            ],
+            examples=[
+                {
+                    "action": "run",
+                    "task_type": "translate",
+                    "input_path": "/path/to/file.txt",
+                    "source_lang": "Japanese",
+                    "target_lang": "Chinese",
+                    "profile": "default",
+                },
+                {"action": "status"},
+            ],
+        )
+
+    def _run_translate_subprocess(self, args: Dict[str, Any]) -> SkillResult:
+        """Execute translation via CLI subprocess (混合模式: CLI fallback)."""
+        cli_args = [args.get("task_type", "translate")]
+
+        if args.get("input_path"):
+            cli_args.append(args["input_path"])
+        if args.get("output_path"):
+            cli_args.extend(["-o", args["output_path"]])
+        if args.get("profile"):
+            cli_args.extend(["-p", args["profile"]])
+        if args.get("source_lang"):
+            cli_args.extend(["-s", args["source_lang"]])
+        if args.get("target_lang"):
+            cli_args.extend(["-t", args["target_lang"]])
+        if args.get("project_type"):
+            cli_args.extend(["--type", args["project_type"]])
+        if args.get("threads"):
+            cli_args.extend(["--threads", str(args["threads"])])
+        if args.get("model"):
+            cli_args.extend(["--model", args["model"]])
+        if args.get("platform"):
+            cli_args.extend(["--platform", args["platform"]])
+        if args.get("resume"):
+            cli_args.append("--resume")
+
+        # Non-interactive mode for automation
+        cli_args.append("--yes")
+
+        try:
+            result = _run_ainiee_cli(cli_args, timeout=3600)
+            return SkillResult.ok({
+                "exit_code": result.returncode,
+                "stdout": result.stdout[-2000:] if result.stdout else "",
+                "stderr": result.stderr[-2000:] if result.stderr else "",
+                "command": "uv run ainiee_cli.py " + " ".join(cli_args),
+            })
+        except subprocess.TimeoutExpired:
+            return SkillResult.fail("Translation task timed out.", "TIMEOUT")
+        except FileNotFoundError as e:
+            return SkillResult.fail(f"Python executable not found: {e}", "RUNTIME_ERROR")
+
+    def execute(self, args: Dict[str, Any]) -> SkillResult:
+        action = (args.get("action") or "").strip().lower()
+
+        if action == "status":
+            # Check if a task is currently running by looking for PID/lock files
+            return SkillResult.ok({
+                "running": False,
+                "note": "Task status check available via WebServer API when running.",
+            })
+
+        if action == "run":
+            # 混合模式: 通过CLI子进程执行
+            return self._run_translate_subprocess(args)
+
+        return SkillResult.fail(f"Unknown translate action: {action}", "INVALID_ACTION")


### PR DESCRIPTION
提供一套零依赖的 Skills 框架。
Skills 通过纯 Python 标准库实现 REST/JSON API，无需 MCP、FastAPI、uvicorn。

核心能力：
- 6 个内置 skill：system（系统信息）、config（配置读写）、translate（翻译执行） queue（队列管理）、profile（配置切换）、file（文件操作）
- HTTP 服务：GET /skills 列举、POST /skills/<name> 执行、GET /health 健康检查
- CLI 模式：python Tools/Skills/cli.py list|describe|run|server
- Shell 启动脚本：Tools/Skills/launcher.sh
- 零新增依赖，全部使用 Python 标准库
- 默认端口 8766（与 MCP 的 8765 并列）